### PR TITLE
feat: add AI-ready intent hints

### DIFF
--- a/src/lib/intentSearch.test.ts
+++ b/src/lib/intentSearch.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { ENTRIES } from '../data/seed'
-import { rankEntriesForIntent, shouldUsePlanMode } from './intentSearch'
+import {
+  mockIntentClassifierProvider,
+  rankEntriesForIntent,
+  rankEntriesForIntentWithHints,
+  shouldUsePlanMode,
+  type IntentClassifierProvider,
+} from './intentSearch'
 
 describe('rankEntriesForIntent', () => {
   it('routes clear itinerary prompts to plan mode', () => {
@@ -67,5 +73,62 @@ describe('rankEntriesForIntent', () => {
 
     expect(results[0]?.entry.id).toBe('bluegold-coffee')
     expect(results[0]?.matchedReasons).toContain('matched search text')
+  })
+
+  it('keeps deterministic results unchanged when no AI hints are returned', async () => {
+    const noHintProvider: IntentClassifierProvider = {
+      async classifyIntent() {
+        return null
+      },
+    }
+
+    const deterministicResults = rankEntriesForIntent('ไหว้พระ ขอพร', ENTRIES)
+    const hintedResults = await rankEntriesForIntentWithHints(
+      'ไหว้พระ ขอพร',
+      ENTRIES,
+      noHintProvider,
+    )
+
+    expect(hintedResults).toEqual(deterministicResults)
+  })
+
+  it('uses mock AI hints to annotate and boost Thai ranking results', async () => {
+    const deterministicResults = rankEntriesForIntent('ของกิน อาหารเวียดนาม', ENTRIES)
+    const hintedResults = await rankEntriesForIntentWithHints(
+      'ของกิน อาหารเวียดนาม',
+      ENTRIES,
+      mockIntentClassifierProvider,
+    )
+
+    expect(hintedResults[0]?.entry.id).toBe('pho-sawan')
+    expect(hintedResults[0]?.score).toBeGreaterThan(deterministicResults[0]?.score ?? 0)
+    expect(hintedResults[0]?.matchedReasons).toContain('ai food_trip hint')
+  })
+
+  it('falls back to deterministic results if the provider throws', async () => {
+    const failingProvider: IntentClassifierProvider = {
+      async classifyIntent() {
+        throw new Error('mock provider failure')
+      },
+    }
+
+    const deterministicResults = rankEntriesForIntent('ขอลูก', ENTRIES)
+    const hintedResults = await rankEntriesForIntentWithHints(
+      'ขอลูก',
+      ENTRIES,
+      failingProvider,
+    )
+
+    expect(hintedResults).toEqual(deterministicResults)
+  })
+
+  it('does not throw for unknown queries when using the async wrapper', async () => {
+    await expect(
+      rankEntriesForIntentWithHints(
+        'mystery riverside pastry',
+        ENTRIES,
+        mockIntentClassifierProvider,
+      ),
+    ).resolves.toEqual(rankEntriesForIntent('mystery riverside pastry', ENTRIES))
   })
 })

--- a/src/lib/intentSearch.ts
+++ b/src/lib/intentSearch.ts
@@ -9,13 +9,32 @@ export type RankedEntry = {
   matchedReasons: string[]
 }
 
+export type IntentId =
+  | 'general_blessing'
+  | 'fertility_blessing'
+  | 'birthday_stupa'
+  | 'riverside_evening'
+  | 'food_trip'
+
+export type AiIntentHint = {
+  intentIds: IntentId[]
+  confidence: number
+  matchedTerms: string[]
+  categoryHints?: Entry['category'][]
+  tagHints?: {
+    vibeTags?: string[]
+    cuisineTags?: string[]
+    timeTags?: string[]
+  }
+  provider: 'mock' | string
+}
+
+export type IntentClassifierProvider = {
+  classifyIntent(query: string): Promise<AiIntentHint | null>
+}
+
 type IntentGroup = {
-  id:
-    | 'general_blessing'
-    | 'fertility_blessing'
-    | 'birthday_stupa'
-    | 'riverside_evening'
-    | 'food_trip'
+  id: IntentId
   label: string
   keywords: string[]
   entryBoosts?: Record<string, number>
@@ -217,6 +236,18 @@ function addReason(reasons: Set<string>, reason: string) {
   if (reasons.size < 4) reasons.add(reason)
 }
 
+function addReasonToList(reasons: string[], reason: string) {
+  if (reasons.includes(reason)) return
+  if (reasons.length < 4) {
+    reasons.push(reason)
+    return
+  }
+  if (reason.startsWith('ai ') && reasons.some((existing) => existing.startsWith('ai '))) {
+    return
+  }
+  reasons[reasons.length - 1] = reason
+}
+
 /** Returns the configured intent groups whose keywords appear in the query. */
 function detectIntentGroups(query: string): IntentGroup[] {
   const normalizedQuery = normalize(query)
@@ -305,6 +336,63 @@ function scoreIntentMatch(group: IntentGroup, entry: Entry, reasons: Set<string>
   return score
 }
 
+function scoreAiHintIntentMatch(
+  hint: AiIntentHint,
+  entry: Entry,
+  reasons: string[],
+): number {
+  let score = 0
+  const confidence = Math.max(0, Math.min(1, hint.confidence || 0))
+
+  for (const intentId of hint.intentIds) {
+    const group = INTENT_GROUPS.find((candidate) => candidate.id === intentId)
+    if (!group) continue
+
+    const entryBoost = group.entryBoosts?.[entry.id] ?? 0
+    if (entryBoost > 0) {
+      score += Math.round(entryBoost * 0.2 * confidence)
+      addReasonToList(reasons, `ai ${intentId} hint`)
+    }
+
+    const categoryBoost = group.categories?.[entry.category] ?? 0
+    if (categoryBoost > 0) {
+      score += Math.round(categoryBoost * 0.15 * confidence)
+      addReasonToList(reasons, `ai ${intentId} hint`)
+    }
+
+    if (
+      entry.vibe_tags.some((tag) => (group.vibeTags?.[tag] ?? 0) > 0) ||
+      entry.cuisine_tags.some((tag) => (group.cuisineTags?.[tag] ?? 0) > 0) ||
+      entry.time_tags.some((tag) => (group.timeTags?.[tag] ?? 0) > 0)
+    ) {
+      score += Math.round(4 * confidence)
+      addReasonToList(reasons, `ai ${intentId} hint`)
+    }
+  }
+
+  if (hint.categoryHints?.includes(entry.category)) {
+    score += Math.round(6 * confidence)
+    addReasonToList(reasons, `ai ${entry.category} category`)
+  }
+
+  if (hint.tagHints?.vibeTags?.some((tag) => entry.vibe_tags.includes(tag))) {
+    score += Math.round(4 * confidence)
+    addReasonToList(reasons, 'ai vibe hint')
+  }
+
+  if (hint.tagHints?.cuisineTags?.some((tag) => entry.cuisine_tags.includes(tag))) {
+    score += Math.round(4 * confidence)
+    addReasonToList(reasons, 'ai cuisine hint')
+  }
+
+  if (hint.tagHints?.timeTags?.some((tag) => entry.time_tags.includes(tag))) {
+    score += Math.round(4 * confidence)
+    addReasonToList(reasons, 'ai time hint')
+  }
+
+  return score
+}
+
 /**
  * Ranks mixed Entries for an activity-style query using deterministic intent rules
  * plus text relevance from the current seed data.
@@ -351,4 +439,115 @@ export function rankEntriesForIntent(query: string, entries: Entry[]): RankedEnt
       score: Math.round(score),
       matchedReasons,
     }))
+}
+
+/**
+ * Mock AI-ready provider that emits typed intent hints for known Thai search phrases.
+ * It exists only to prove the async hint interface without any network calls.
+ */
+export const mockIntentClassifierProvider: IntentClassifierProvider = {
+  async classifyIntent(query) {
+    const normalizedQuery = normalize(query)
+    if (!normalizedQuery) return null
+
+    if (
+      normalizedQuery.includes(normalize('ไหว้พระ')) &&
+      normalizedQuery.includes(normalize('ขอพร'))
+    ) {
+      return {
+        intentIds: ['general_blessing'],
+        confidence: 0.88,
+        matchedTerms: ['ไหว้พระ', 'ขอพร'],
+        categoryHints: ['temple', 'landmark'],
+        tagHints: { vibeTags: ['spiritual', 'birthday-stupa'] },
+        provider: 'mock',
+      }
+    }
+
+    if (normalizedQuery.includes(normalize('ขอลูก'))) {
+      return {
+        intentIds: ['fertility_blessing'],
+        confidence: 0.96,
+        matchedTerms: ['ขอลูก'],
+        categoryHints: ['temple'],
+        tagHints: { vibeTags: ['spiritual'] },
+        provider: 'mock',
+      }
+    }
+
+    if (
+      normalizedQuery.includes(normalize('ของกิน')) &&
+      normalizedQuery.includes(normalize('อาหารเวียดนาม'))
+    ) {
+      return {
+        intentIds: ['food_trip'],
+        confidence: 0.91,
+        matchedTerms: ['ของกิน', 'อาหารเวียดนาม'],
+        categoryHints: ['food', 'cafe', 'market'],
+        tagHints: { cuisineTags: ['vietnamese'] },
+        provider: 'mock',
+      }
+    }
+
+    if (normalizedQuery.includes(normalize('พระธาตุประจำวันเกิด'))) {
+      return {
+        intentIds: ['birthday_stupa'],
+        confidence: 0.9,
+        matchedTerms: ['พระธาตุประจำวันเกิด'],
+        categoryHints: ['temple'],
+        tagHints: { vibeTags: ['birthday-stupa', 'spiritual'] },
+        provider: 'mock',
+      }
+    }
+
+    if (
+      normalizedQuery.includes(normalize('ริมโขง')) &&
+      normalizedQuery.includes(normalize('เดินเล่น'))
+    ) {
+      return {
+        intentIds: ['riverside_evening'],
+        confidence: 0.84,
+        matchedTerms: ['ริมโขง', 'เดินเล่น'],
+        categoryHints: ['landmark', 'market', 'cafe'],
+        tagHints: { vibeTags: ['photo-spot', 'iconic'], timeTags: ['sunset', 'evening'] },
+        provider: 'mock',
+      }
+    }
+
+    return null
+  },
+}
+
+/**
+ * Async wrapper that preserves deterministic search while allowing provider-based
+ * intent hints to add small ranking boosts and matched reasons.
+ */
+export async function rankEntriesForIntentWithHints(
+  query: string,
+  entries: Entry[],
+  provider: IntentClassifierProvider,
+): Promise<RankedEntry[]> {
+  const baseResults = rankEntriesForIntent(query, entries)
+
+  try {
+    const hint = await provider.classifyIntent(query)
+    if (!hint) return baseResults
+
+    return baseResults
+      .map((result, index) => {
+        const matchedReasons = [...result.matchedReasons]
+        const boostedScore = result.score + scoreAiHintIntentMatch(hint, result.entry, matchedReasons)
+
+        return {
+          ...result,
+          index,
+          score: boostedScore,
+          matchedReasons,
+        }
+      })
+      .sort((a, b) => b.score - a.score || a.index - b.index)
+      .map(({ index: _index, ...result }) => result)
+  } catch {
+    return baseResults
+  }
 }

--- a/src/lib/intentSearch.ts
+++ b/src/lib/intentSearch.ts
@@ -9,6 +9,7 @@ export type RankedEntry = {
   matchedReasons: string[]
 }
 
+/** Canonical intent ids shared by deterministic and AI-assisted ranking. */
 export type IntentId =
   | 'general_blessing'
   | 'fertility_blessing'
@@ -16,6 +17,7 @@ export type IntentId =
   | 'riverside_evening'
   | 'food_trip'
 
+/** Provider-neutral hint payload that can nudge deterministic ranking. */
 export type AiIntentHint = {
   intentIds: IntentId[]
   confidence: number
@@ -29,6 +31,7 @@ export type AiIntentHint = {
   provider: 'mock' | string
 }
 
+/** Async classifier contract for future server-side or mock intent providers. */
 export type IntentClassifierProvider = {
   classifyIntent(query: string): Promise<AiIntentHint | null>
 }
@@ -236,6 +239,7 @@ function addReason(reasons: Set<string>, reason: string) {
   if (reasons.size < 4) reasons.add(reason)
 }
 
+/** Adds one short reason while keeping AI-specific annotations visible in the cap. */
 function addReasonToList(reasons: string[], reason: string) {
   if (reasons.includes(reason)) return
   if (reasons.length < 4) {
@@ -336,6 +340,7 @@ function scoreIntentMatch(group: IntentGroup, entry: Entry, reasons: Set<string>
   return score
 }
 
+/** Applies small additive boosts from AI intent hints to an already-ranked entry. */
 function scoreAiHintIntentMatch(
   hint: AiIntentHint,
   entry: Entry,
@@ -521,6 +526,7 @@ export const mockIntentClassifierProvider: IntentClassifierProvider = {
 /**
  * Async wrapper that preserves deterministic search while allowing provider-based
  * intent hints to add small ranking boosts and matched reasons.
+ * Provider failures or missing hints return deterministic results unchanged.
  */
 export async function rankEntriesForIntentWithHints(
   query: string,

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -12,7 +12,8 @@ import { themesForCity } from '../data/themes'
 import { distanceKm } from '../lib/distance'
 import { CHIPS, applyFilters } from '../lib/filters'
 import {
-  rankEntriesForIntent,
+  mockIntentClassifierProvider,
+  rankEntriesForIntentWithHints,
   shouldUsePlanMode,
   type RankedEntry,
 } from '../lib/intentSearch'
@@ -94,7 +95,11 @@ export default function MapPage() {
       return
     }
 
-    const rankedResults = rankEntriesForIntent(query, entries)
+    const rankedResults = await rankEntriesForIntentWithHints(
+      query,
+      entries,
+      mockIntentClassifierProvider,
+    )
     if (rankedResults.length > 0) {
       setActiveSearch({ query, results: rankedResults })
       setSheetState('full')


### PR DESCRIPTION
## Summary

Adds a small AI-ready intent hint layer on top of the existing deterministic search without replacing current behavior.

## What changed

- Added provider-neutral intent hint types in `src/lib/intentSearch.ts`
- Kept `rankEntriesForIntent()` as the deterministic core
- Added `mockIntentClassifierProvider` for known Thai activity-query patterns
- Added `rankEntriesForIntentWithHints()` as an async additive wrapper
- Updated `MapPage` to await the async wrapper for non-plan queries
- Added tests for:
  - unchanged deterministic behavior when no hints are returned
  - additive mock AI hint annotation/boosts
  - provider failure fallback to deterministic ranking
  - unknown query safety

## Behavior

- Plan-like queries still route to `getPlan()`
- Non-plan queries still use ranked search
- No-result search still falls back to `getPlan()`
- No real AI API calls, env vars, backend routes, or dependency changes were added

## Verification

- `npm.cmd test`
- `npm.cmd run build`
- `git diff --check`

## Notes

- `package.json` and `package-lock.json` were not changed
- The mock provider is intentionally narrow and only proves the async hint seam
- AI hints are additive only and do not surface entries that deterministic ranking excluded
- Branch has already been rebased onto the latest `origin/main`

## Review focus

- Confirm the AI hint layer stays additive and does not replace deterministic search
- Confirm future real providers should remain server-side
- Confirm the async search path does not create UX regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI-powered search ranking that improves result relevance based on user intent and search context
  * Smarter scoring system that boosts relevant results based on categories and tags

* **Tests**
  * Comprehensive test coverage for the AI-intent ranking system with multiple scenarios and fallback behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->