### PR TITLE
test: add search evaluation cases

### DIFF
--- a/src/lib/searchEvaluation.test.ts
+++ b/src/lib/searchEvaluation.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import { ENTRIES } from '../data/seed'
+import {
+  mockIntentClassifierProvider,
+  rankEntriesForIntent,
+  rankEntriesForIntentWithHints,
+  shouldUsePlanMode,
+} from './intentSearch'
+import { SEARCH_EVALUATION_CASES } from './searchEvaluationCases'
+
+const planCases = SEARCH_EVALUATION_CASES.filter((testCase) => testCase.expectedMode === 'plan')
+const searchCases = SEARCH_EVALUATION_CASES.filter((testCase) => testCase.expectedMode === 'search')
+const mockHintQueries = searchCases.filter((testCase) => testCase.expectedReasonSubstring?.startsWith('ai '))
+
+describe('search evaluation set', () => {
+  it('keeps plan-mode prompts routed to plan mode', () => {
+    for (const testCase of planCases) {
+      expect(shouldUsePlanMode(testCase.query), testCase.notes).toBe(true)
+    }
+  })
+
+  it('keeps search-mode prompts out of plan mode', () => {
+    for (const testCase of searchCases) {
+      expect(shouldUsePlanMode(testCase.query), testCase.notes).toBe(false)
+    }
+  })
+
+  it('keeps search-mode cases sensible with AI hints', async () => {
+    for (const testCase of searchCases) {
+      const results = await rankEntriesForIntentWithHints(
+        testCase.query,
+        ENTRIES,
+        mockIntentClassifierProvider,
+      )
+
+      if (testCase.query === 'zzqv mystery phrase') {
+        expect(results, testCase.notes).toEqual([])
+        continue
+      }
+
+      expect(results.length, testCase.notes).toBeGreaterThan(0)
+
+      const window = testCase.topWindow ?? 3
+      const topResults = results.slice(0, window)
+      const topIds = topResults.map((result) => result.entry.id)
+      const topCategories = topResults.map((result) => result.entry.category)
+
+      if (testCase.expectedTopId) {
+        expect(topIds, testCase.notes).toContain(testCase.expectedTopId)
+      }
+
+      if (testCase.expectedTopIds) {
+        for (const expectedTopId of testCase.expectedTopIds) {
+          expect(topIds, `${testCase.notes} (${expectedTopId})`).toContain(expectedTopId)
+        }
+      }
+
+      if (testCase.expectedTopCategories) {
+        for (const expectedCategory of testCase.expectedTopCategories) {
+          expect(topCategories, `${testCase.notes} (${expectedCategory})`).toContain(expectedCategory)
+        }
+      }
+
+      if (testCase.expectedReasonSubstring) {
+        const topReasonText = topResults
+          .flatMap((result) => result.matchedReasons)
+          .join(' | ')
+        expect(topReasonText, testCase.notes).toContain(testCase.expectedReasonSubstring)
+      }
+    }
+  })
+
+  it('does not let AI hints make known search cases worse', async () => {
+    for (const testCase of mockHintQueries) {
+      const deterministicResults = rankEntriesForIntent(testCase.query, ENTRIES)
+      const hintedResults = await rankEntriesForIntentWithHints(
+        testCase.query,
+        ENTRIES,
+        mockIntentClassifierProvider,
+      )
+
+      expect(hintedResults.length, testCase.notes).toBeGreaterThan(0)
+
+      if (testCase.expectedTopId) {
+        const deterministicTopIds = deterministicResults.slice(0, 3).map((result) => result.entry.id)
+        const hintedTopIds = hintedResults.slice(0, 3).map((result) => result.entry.id)
+
+        expect(deterministicTopIds, testCase.notes).toContain(testCase.expectedTopId)
+        expect(hintedTopIds, testCase.notes).toContain(testCase.expectedTopId)
+      }
+
+      if (testCase.expectedTopCategories) {
+        const hintedTopCategories = hintedResults
+          .slice(0, testCase.topWindow ?? 3)
+          .map((result) => result.entry.category)
+
+        expect(hintedTopCategories, testCase.notes).toEqual(
+          expect.arrayContaining(testCase.expectedTopCategories),
+        )
+      }
+
+      const hintedReasonText = hintedResults[0]?.matchedReasons.join(' | ') ?? ''
+      expect(hintedReasonText, testCase.notes).toContain('ai ')
+    }
+  })
+
+  it('keeps the civet coffee fallback stable with the evaluation data', async () => {
+    const results = await rankEntriesForIntentWithHints(
+      'civet coffee farm',
+      ENTRIES,
+      mockIntentClassifierProvider,
+    )
+
+    expect(results[0]?.entry.id).toBe('bluegold-coffee')
+    expect(results[0]?.matchedReasons).toContain('matched search text')
+  })
+})

--- a/src/lib/searchEvaluationCases.ts
+++ b/src/lib/searchEvaluationCases.ts
@@ -1,0 +1,79 @@
+export type SearchEvaluationMode = 'search' | 'plan'
+
+export type SearchEvaluationCase = {
+  query: string
+  expectedMode: SearchEvaluationMode
+  expectedTopId?: string
+  expectedTopIds?: string[]
+  expectedTopCategories?: string[]
+  expectedReasonSubstring?: string
+  topWindow?: number
+  notes: string
+}
+
+export const SEARCH_EVALUATION_CASES: SearchEvaluationCase[] = [
+  {
+    query: 'ไหว้พระ ขอพร',
+    expectedMode: 'search',
+    expectedTopIds: ['wat-phra-that-phanom', 'naga-statue', 'phra-that-renu'],
+    expectedReasonSubstring: 'ai general_blessing hint',
+    topWindow: 5,
+    notes: 'Core blessing query should surface spiritual landmarks and temples near the top.',
+  },
+  {
+    query: 'ขอลูก',
+    expectedMode: 'search',
+    expectedTopId: 'wat-phra-that-phanom',
+    expectedReasonSubstring: 'ai fertility_blessing hint',
+    notes: 'Fertility blessing query should keep Wat Phra That Phanom as the top result.',
+  },
+  {
+    query: 'ของกิน อาหารเวียดนาม',
+    expectedMode: 'search',
+    expectedTopId: 'pho-sawan',
+    expectedTopCategories: ['food', 'market'],
+    expectedReasonSubstring: 'ai food_trip hint',
+    topWindow: 3,
+    notes: 'Food trip query should prioritize food-first results and keep the mock AI hint visible.',
+  },
+  {
+    query: 'พระธาตุประจำวันเกิด',
+    expectedMode: 'search',
+    expectedTopIds: ['wat-phra-that-phanom', 'phra-that-renu'],
+    expectedTopCategories: ['temple'],
+    expectedReasonSubstring: 'ai birthday_stupa hint',
+    topWindow: 5,
+    notes: 'Birthday-stupa search should remain in search mode and keep temples near the top.',
+  },
+  {
+    query: 'ริมโขง เดินเล่น',
+    expectedMode: 'search',
+    expectedTopIds: ['naga-statue', 'indochina-walking-street', 'river-vibes-cafe'],
+    expectedTopCategories: ['landmark', 'market', 'cafe'],
+    expectedReasonSubstring: 'ai riverside_evening hint',
+    topWindow: 5,
+    notes: 'Riverside evening search should surface walkable Mekong-adjacent results.',
+  },
+  {
+    query: 'I have one afternoon, I love food and history',
+    expectedMode: 'plan',
+    notes: 'Existing itinerary demo prompt must stay in plan mode.',
+  },
+  {
+    query: 'I was born on Sunday',
+    expectedMode: 'plan',
+    notes: 'English birthday-plan prompt must keep using plan mode.',
+  },
+  {
+    query: 'civet coffee farm',
+    expectedMode: 'search',
+    expectedTopId: 'bluegold-coffee',
+    expectedReasonSubstring: 'matched search text',
+    notes: 'Fallback text relevance should still find the civet coffee entry.',
+  },
+  {
+    query: 'zzqv mystery phrase',
+    expectedMode: 'search',
+    notes: 'Unknown query should not throw even when neither deterministic nor AI hints match.',
+  },
+]


### PR DESCRIPTION
## Summary

Adds a data-driven search evaluation set for the intent search system.

## What changed

- Added `src/lib/searchEvaluationCases.ts`
- Added `src/lib/searchEvaluation.test.ts`

## Coverage

- Thai search-mode queries:
  - `ไหว้พระ ขอพร`
  - `ขอลูก`
  - `ของกิน อาหารเวียดนาม`
  - `พระธาตุประจำวันเกิด`
  - `ริมโขง เดินเล่น`
- Plan-mode queries:
  - `I have one afternoon, I love food and history`
  - `I was born on Sunday`
- Fallback / robustness queries:
  - `civet coffee farm`
  - A nonsense query that should not throw

## Notes

- Uses `rankEntriesForIntentWithHints()` with the mock provider for search-mode cases
- Keeps checks focused on stable behavior like top results, categories, and reason substrings
- Does not change production search logic, ranking weights, UI, dependencies, or package files

## Verification

- `npm.cmd test`
- `npm.cmd run build`
- `git diff --check`

## Review focus

- Confirm the evaluation cases are stable enough for future seed-data changes
- Confirm the assertions are not overfitted to exact scores
- Confirm this should remain a test-only PR