### PR TITLE
fix: point demo frontend to backend fallback

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,8 +1,9 @@
 import type { Entry, LiveStatus } from '../types'
 import { ENTRIES as LOCAL_SEED } from '../data/seed'
 
-const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined)?.trim() || 'http://127.0.0.1:8000'
-const API_KEY = (import.meta.env.VITE_API_KEY as string | undefined)?.trim() || 'dev-local-key'
+// Temporary demo fallback until Vercel env vars are configured for the deployed frontend.
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined)?.trim() || 'https://pattarabordee-nakhon-phanom-backend.hf.space'
+const API_KEY = (import.meta.env.VITE_API_KEY as string | undefined)?.trim() || 'nkp-demo-key-2026'
 
 type ApiEntry = {
   id: string


### PR DESCRIPTION
## Summary

Temporarily points the deployed frontend fallback API defaults to the Hugging Face backend for demo use.

## What changed

- Updated `src/lib/api.ts`
- Kept `VITE_API_BASE_URL` and `VITE_API_KEY` override support
- Changed fallback defaults from localhost/dev key to the deployed backend URL and demo API key
- Added a comment marking this as a temporary demo fallback until Vercel env vars are configured

## Verification

- `npm.cmd test`
- `npm.cmd run build`
- `npm.cmd run test:e2e -- --reporter=list`
- `git diff --check`

## Notes

- This is a temporary demo shortcut
- No OpenRouter key or backend secret was added
- Long term, these values should move to Vercel Environment Variables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default API configuration fallbacks to use the deployed backend service instead of the local development server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->