### PR TITLE
feat: add concierge chat MVP

### DIFF
--- a/src/components/ChatResultCard.tsx
+++ b/src/components/ChatResultCard.tsx
@@ -1,0 +1,69 @@
+import { ChevronRight } from 'lucide-react'
+import { isOpenNow } from '../lib/status'
+import { STATUS_COLOR, STATUS_LABEL } from '../lib/statusDisplay'
+import type { Entry } from '../types'
+
+type Props = {
+  entry: Entry
+  score: number
+  matchedReasons: string[]
+  onTap?: (entry: Entry) => void
+}
+
+export default function ChatResultCard({ entry, score, matchedReasons, onTap }: Props) {
+  const status = isOpenNow(entry, new Date())
+
+  return (
+    <button
+      type="button"
+      onClick={() => onTap?.(entry)}
+      className="w-full rounded-kit-photo border border-ink/8 bg-white p-3 text-left shadow-kit-card transition hover:shadow-kit-frame"
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className="grid h-14 w-14 shrink-0 place-items-center rounded-kit-photo bg-kit-cream-1 text-2xl"
+          style={
+            entry.photos?.[0]
+              ? { backgroundImage: `url(${entry.photos[0]})`, backgroundSize: 'cover', backgroundPosition: 'center' }
+              : undefined
+          }
+        >
+          {entry.photos?.[0] ? '' : entry.emoji}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-2">
+            <div className="min-w-0">
+              <h3 className="truncate text-[14px] font-extrabold tracking-tight text-ink">{entry.name_en}</h3>
+              <p className="truncate text-[11px] font-semibold text-muted">{entry.name_th}</p>
+            </div>
+            <div className="rounded-kit-pill bg-blue-strong/10 px-2 py-1 text-[10px] font-extrabold uppercase tracking-wide text-blue-strong">
+              {score} pts
+            </div>
+          </div>
+          <div className="mt-2 flex items-center gap-2 text-[11px] font-bold text-muted">
+            <span
+              className="inline-block h-2 w-2 rounded-full"
+              style={{ background: STATUS_COLOR[status] }}
+            />
+            <span>{STATUS_LABEL[status]}</span>
+            <span className="text-ink/20">/</span>
+            <span className="capitalize">{entry.category}</span>
+          </div>
+          {matchedReasons.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {matchedReasons.slice(0, 3).map((reason) => (
+                <span
+                  key={reason}
+                  className="rounded-kit-pill bg-panel px-2 py-1 text-[10px] font-bold text-ink/70"
+                >
+                  {reason}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+        <ChevronRight size={16} className="mt-1 shrink-0 text-blue-strong" aria-hidden="true" />
+      </div>
+    </button>
+  )
+}

--- a/src/components/ChatbotBar.tsx
+++ b/src/components/ChatbotBar.tsx
@@ -7,9 +7,10 @@ type Props = {
   initialQuery?: string
   onClear?: () => void
   hasPlan?: boolean
+  className?: string
 }
 
-export default function ChatbotBar({ onSubmit, loading, initialQuery, onClear, hasPlan }: Props) {
+export default function ChatbotBar({ onSubmit, loading, initialQuery, onClear, hasPlan, className }: Props) {
   const [value, setValue] = useState(initialQuery ?? '')
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -25,7 +26,7 @@ export default function ChatbotBar({ onSubmit, loading, initialQuery, onClear, h
   }
 
   return (
-    <div className="absolute top-4 left-4 right-4 z-kit-overlay">
+    <div className={className ?? 'absolute top-4 left-4 right-4 z-kit-overlay'}>
       <form
         onSubmit={handleSubmit}
         role="search"

--- a/src/components/PlanMyDaySheet.tsx
+++ b/src/components/PlanMyDaySheet.tsx
@@ -1,0 +1,128 @@
+type DurationOption = '1 Hour' | 'Half-Day' | 'Full-Day'
+type VibeOption = 'Spiritual' | 'Food' | 'Nature' | 'Photo' | 'Family' | 'Hidden Gem'
+type PaceOption = 'Relaxed' | 'Balanced' | 'Packed'
+
+export type PlanMyDaySelections = {
+  duration: DurationOption
+  vibe: VibeOption
+  pace: PaceOption
+}
+
+type Props = {
+  open: boolean
+  selections: PlanMyDaySelections
+  onChange: (next: PlanMyDaySelections) => void
+  onClose: () => void
+  onSubmit: () => void
+  loading: boolean
+}
+
+const DURATIONS: DurationOption[] = ['1 Hour', 'Half-Day', 'Full-Day']
+const VIBES: VibeOption[] = ['Spiritual', 'Food', 'Nature', 'Photo', 'Family', 'Hidden Gem']
+const PACES: PaceOption[] = ['Relaxed', 'Balanced', 'Packed']
+
+function ChipGroup<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+}: {
+  label: string
+  options: T[]
+  value: T
+  onChange: (next: T) => void
+}) {
+  return (
+    <div>
+      <p className="mb-2 text-[11px] font-extrabold uppercase tracking-[0.18em] text-kit-eyebrow">
+        {label}
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {options.map((option) => {
+          const active = option === value
+          return (
+            <button
+              key={option}
+              type="button"
+              onClick={() => onChange(option)}
+              className={`kit-chip ${active ? 'kit-chip-active' : 'kit-chip-inactive'}`}
+            >
+              {option}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default function PlanMyDaySheet({
+  open,
+  selections,
+  onChange,
+  onClose,
+  onSubmit,
+  loading,
+}: Props) {
+  if (!open) return null
+
+  return (
+    <div className="absolute inset-0 z-[80] bg-ink/30 backdrop-blur-[2px]">
+      <button
+        type="button"
+        aria-label="Close plan my day sheet"
+        className="absolute inset-0"
+        onClick={onClose}
+      />
+      <div className="absolute inset-x-0 bottom-0 rounded-t-[32px] bg-white px-4 pb-6 pt-4 shadow-sheet">
+        <div className="mx-auto mb-4 h-[5px] w-11 rounded-full bg-ink/20" />
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="kit-eyebrow mb-2">Quick planner</p>
+            <h2 className="text-xl font-black tracking-[-0.04em] text-ink">Plan my day</h2>
+            <p className="mt-1 text-sm text-muted">
+              Pick a vibe, pace, and trip length. We&apos;ll turn it into one itinerary prompt.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-kit-pill px-3 py-2 text-sm font-bold text-muted hover:bg-panel hover:text-ink"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="mt-5 space-y-4">
+          <ChipGroup
+            label="Duration"
+            options={DURATIONS}
+            value={selections.duration}
+            onChange={(duration) => onChange({ ...selections, duration })}
+          />
+          <ChipGroup
+            label="Vibe"
+            options={VIBES}
+            value={selections.vibe}
+            onChange={(vibe) => onChange({ ...selections, vibe })}
+          />
+          <ChipGroup
+            label="Pace"
+            options={PACES}
+            value={selections.pace}
+            onChange={(pace) => onChange({ ...selections, pace })}
+          />
+        </div>
+
+        <button
+          type="button"
+          onClick={onSubmit}
+          disabled={loading}
+          className="mt-6 w-full rounded-kit-pill bg-ink px-4 py-3 text-sm font-extrabold text-white transition hover:bg-ink/90 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {loading ? 'Planning...' : 'Create plan'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -1,10 +1,13 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
+import { ChevronRight, LoaderCircle, Map as MapIcon, MessageCircle, Sparkles } from 'lucide-react'
 import BottomSheet, { type SheetState } from '../components/BottomSheet'
-import KitBottomNav2 from '../components/KitBottomNav2'
 import ChatbotBar from '../components/ChatbotBar'
+import ChatResultCard from '../components/ChatResultCard'
 import EntryCard from '../components/EntryCard'
+import KitBottomNav2 from '../components/KitBottomNav2'
 import MapView from '../components/MapView'
+import PlanMyDaySheet, { type PlanMyDaySelections } from '../components/PlanMyDaySheet'
 import PlanResult from '../components/PlanResult'
 import ThemeStrip from '../components/ThemeStrip'
 import { NKP } from '../data/seed'
@@ -21,49 +24,326 @@ import { getPlan, type Plan } from '../lib/plan'
 import { useAppStore } from '../store/useAppStore'
 import type { Entry } from '../types'
 
+type RankedSearchResult = {
+  entry: Entry
+  score: number
+  matchedReasons: string[]
+}
+
 type ActiveSearch = {
   query: string
-  results: Array<{
-    entry: Entry
-    score: number
-    matchedReasons: string[]
-  }>
+  results: RankedSearchResult[]
+}
+
+type ViewMode = 'chat' | 'map'
+
+type ChatMessage = {
+  id: string
+  role: 'assistant' | 'user'
+  text: string
+  results?: RankedSearchResult[]
+  plan?: Plan
+}
+
+const INITIAL_CHAT_MESSAGE: ChatMessage = {
+  id: 'assistant-intro',
+  role: 'assistant',
+  text: 'Ask me about blessings, food, nature, photo spots, or trip planning in Nakhon Phanom.',
+}
+
+const INITIAL_PLAN_SELECTIONS: PlanMyDaySelections = {
+  duration: 'Half-Day',
+  vibe: 'Spiritual',
+  pace: 'Balanced',
+}
+
+function buildPlanPrompt(selections: PlanMyDaySelections): string {
+  const durationText: Record<PlanMyDaySelections['duration'], string> = {
+    '1 Hour': 'one hour',
+    'Half-Day': 'a half-day',
+    'Full-Day': 'a full-day',
+  }
+  const vibeText: Record<PlanMyDaySelections['vibe'], string> = {
+    Spiritual: 'spiritual blessings, temple stops, and a stupa visit',
+    Food: 'local food and market snacks',
+    Nature: 'nature, riverside air, and scenic stops',
+    Photo: 'photo spots, viewpoints, and golden-hour scenes',
+    Family: 'family-friendly stops with easy pacing',
+    'Hidden Gem': 'hidden gems and quieter local places',
+  }
+  const paceText: Record<PlanMyDaySelections['pace'], string> = {
+    Relaxed: 'relaxed',
+    Balanced: 'balanced',
+    Packed: 'packed',
+  }
+
+  return `Plan ${durationText[selections.duration]} in Nakhon Phanom with a ${paceText[selections.pace]} pace focused on ${vibeText[selections.vibe]}.`
+}
+
+function buildSearchReply(query: string, results: RankedSearchResult[]): string {
+  if (results.length === 0) {
+    return `I could not find a strong match for "${query}", but you can still explore the map and nearby picks.`
+  }
+
+  const [first, second] = results
+  if (!second) {
+    return `I found one strong match for "${query}". ${first.entry.name_en} looks like the best place to start.`
+  }
+
+  return `I found ${results.length} matches for "${query}". Start with ${first.entry.name_en}, then keep ${second.entry.name_en} as a strong backup.`
+}
+
+function buildPlanReply(plan: Plan): string {
+  return `I mapped out ${plan.stops.length} stops over ${plan.total_duration_min} minutes. Here is a concierge-style route you can follow.`
+}
+
+function ChatBubble({
+  role,
+  children,
+}: {
+  role: ChatMessage['role']
+  children: ReactNode
+}) {
+  const user = role === 'user'
+
+  return (
+    <div className={`flex ${user ? 'justify-end' : 'justify-start'}`}>
+      <div
+        className={
+          user
+            ? 'max-w-[82%] rounded-[22px] rounded-br-md bg-ink px-4 py-3 text-sm font-semibold text-white shadow-kit-card'
+            : 'max-w-[88%] rounded-[22px] rounded-bl-md border border-ink/5 bg-white px-4 py-3 text-sm text-ink shadow-kit-card'
+        }
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function ChatPlanCard({ plan, onOpenEntry }: { plan: Plan; onOpenEntry: (entryId: string) => void }) {
+  return (
+    <div className="rounded-[24px] border border-ink/8 bg-white p-4 shadow-kit-card">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div>
+          <p className="kit-eyebrow mb-2">Your plan</p>
+          <h3 className="text-lg font-black tracking-[-0.04em] text-ink">
+            {plan.start_time} to {plan.end_time}
+          </h3>
+          <p className="mt-1 text-sm text-muted">{plan.rationale_en}</p>
+        </div>
+        <div className="rounded-kit-pill bg-blue-strong/10 px-3 py-2 text-[11px] font-extrabold uppercase tracking-wide text-blue-strong">
+          {plan.stops.length} stops
+        </div>
+      </div>
+
+      <div className="space-y-2.5">
+        {plan.stops.map((stop) => (
+          <button
+            key={stop.position}
+            type="button"
+            onClick={() => onOpenEntry(stop.entry_id)}
+            className="flex w-full items-start gap-3 rounded-kit-photo bg-panel px-3 py-3 text-left transition hover:bg-kit-cream-2"
+          >
+            <div className="grid h-9 w-9 shrink-0 place-items-center rounded-kit-pill bg-white text-sm font-extrabold text-blue-strong shadow-kit-pill">
+              {stop.position}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2 text-[11px] font-extrabold uppercase tracking-wide text-kit-eyebrow">
+                <span>{stop.arrival_time}</span>
+                <span className="text-ink/20">/</span>
+                <span>{stop.duration_min} min</span>
+              </div>
+              <h4 className="truncate text-[14px] font-extrabold tracking-tight text-ink">
+                {stop.entry_summary.name_en}
+              </h4>
+              <p className="mt-1 line-clamp-2 text-[12px] text-muted">{stop.why_en}</p>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
 }
 
 export default function MapPage() {
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const entries = useAppStore((s) => s.entries)
+  const [viewMode, setViewMode] = useState<ViewMode>('chat')
   const [sheetState, setSheetState] = useState<SheetState>('peek')
   const [selectedChipIds, setSelectedChipIds] = useState<string[]>([])
   const [activeThemeId, setActiveThemeId] = useState<string | null>(null)
   const [activeSearch, setActiveSearch] = useState<ActiveSearch | null>(null)
   const [activeStatusFilters, setActiveStatusFilters] = useState<Array<'open_now' | 'closing_soon' | 'closed' | 'unknown'>>([])
-
-  // Chatbot / plan orchestration
   const [chatbotLoading, setChatbotLoading] = useState(false)
   const [activePlan, setActivePlan] = useState<Plan | null>(null)
   const [routeRevealedSegments, setRouteRevealedSegments] = useState(0)
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([INITIAL_CHAT_MESSAGE])
+  const [chatDraft, setChatDraft] = useState('')
+  const [chatThinking, setChatThinking] = useState(false)
+  const [planSheetOpen, setPlanSheetOpen] = useState(false)
+  const [planSelections, setPlanSelections] = useState(INITIAL_PLAN_SELECTIONS)
+  const chatScrollRef = useRef<HTMLDivElement | null>(null)
 
   const themes = useMemo(() => themesForCity('nkp'), [])
   const activeTheme = useMemo(
-    () => themes.find((t) => t.id === activeThemeId) ?? null,
+    () => themes.find((theme) => theme.id === activeThemeId) ?? null,
     [themes, activeThemeId],
   )
 
-  // Filter pipeline: theme narrows the candidate set first; chips refine.
   const filteredEntries = useMemo(() => {
     const candidates = activeTheme
-      ? entries.filter((e) => activeTheme.entry_ids.includes(e.id))
+      ? entries.filter((entry) => activeTheme.entry_ids.includes(entry.id))
       : entries
     return applyFilters(candidates, selectedChipIds, new Date())
   }, [entries, selectedChipIds, activeTheme])
 
+  useEffect(() => {
+    if (!chatScrollRef.current) return
+    chatScrollRef.current.scrollTo({ top: chatScrollRef.current.scrollHeight, behavior: 'smooth' })
+  }, [chatMessages, chatThinking])
+
+  const addChatMessage = (message: ChatMessage) => {
+    setChatMessages((prev) => [...prev, message])
+  }
+
+  const handleCardTap = (id: string) => {
+    navigate(`/entry/${id}`)
+  }
+
+  const prepareFreshResults = () => {
+    setActivePlan(null)
+    setRouteRevealedSegments(0)
+    setSelectedChipIds([])
+    setActiveThemeId(null)
+    setActiveSearch(null)
+  }
+
+  const resolveSearchResults = async (query: string): Promise<ActiveSearch> => {
+    const hits = await searchIntentHits('nkp', query, 12, activeStatusFilters).catch(() => [])
+    const byId = new Map(entries.map((entry) => [entry.id, entry]))
+    let rankedResults = hits
+      .map((hit) => {
+        const entry = byId.get(hit.entryId)
+        if (!entry) return null
+        const matchedReasons = [hit.matchedIntent, hit.category].filter(
+          (value): value is string => Boolean(value),
+        )
+        if (hit.retrievalGrade) matchedReasons.push(`grade:${hit.retrievalGrade}`)
+        return {
+          entry,
+          score: Math.round(hit.score * 100),
+          matchedReasons,
+        }
+      })
+      .filter((result): result is RankedSearchResult => result !== null)
+
+    if (rankedResults.length === 0) {
+      rankedResults = await rankEntriesForIntentWithHints(
+        query,
+        entries,
+        mockIntentClassifierProvider,
+      )
+    }
+
+    const nextSearch = { query, results: rankedResults }
+    setActiveSearch(nextSearch)
+    setSheetState('full')
+    return nextSearch
+  }
+
+  const runConciergeQuery = async (
+    query: string,
+    options?: { appendToChat?: boolean; forcePlan?: boolean; switchToMap?: boolean },
+  ) => {
+    const normalized = query.trim()
+    if (!normalized) return
+
+    prepareFreshResults()
+
+    if (options?.switchToMap) {
+      setViewMode('map')
+    }
+
+    if (options?.appendToChat) {
+      addChatMessage({
+        id: `user-${Date.now()}`,
+        role: 'user',
+        text: normalized,
+      })
+      setChatThinking(true)
+    }
+
+    setChatbotLoading(true)
+
+    try {
+      if (options?.forcePlan || shouldUsePlanMode(normalized)) {
+        const plan = await getPlan(normalized, 'nkp')
+        setActivePlan(plan)
+        setSheetState('full')
+
+        if (options?.appendToChat) {
+          addChatMessage({
+            id: `assistant-plan-${Date.now()}`,
+            role: 'assistant',
+            text: buildPlanReply(plan),
+            plan,
+          })
+        }
+      } else {
+        const search = await resolveSearchResults(normalized)
+        if (options?.appendToChat) {
+          addChatMessage({
+            id: `assistant-search-${Date.now()}`,
+            role: 'assistant',
+            text: buildSearchReply(normalized, search.results),
+            results: search.results.slice(0, 3),
+          })
+        }
+      }
+    } catch {
+      if (options?.appendToChat) {
+        addChatMessage({
+          id: `assistant-error-${Date.now()}`,
+          role: 'assistant',
+          text: 'I hit a temporary snag, but you can still try again or switch to the map to explore.',
+        })
+      }
+    } finally {
+      setChatThinking(false)
+      setChatbotLoading(false)
+    }
+  }
+
+  const handleMapSubmit = async (query: string) => {
+    await runConciergeQuery(query, { appendToChat: true, switchToMap: true })
+  }
+
+  const handleChatSubmit = async (query: string) => {
+    setChatDraft('')
+    await runConciergeQuery(query, { appendToChat: true })
+  }
+
+  const handlePlanMyDay = async () => {
+    setPlanSheetOpen(false)
+    await runConciergeQuery(buildPlanPrompt(planSelections), { appendToChat: true, forcePlan: true })
+  }
+
+  const handleClearResults = () => {
+    setActiveSearch(null)
+    setActivePlan(null)
+    setSelectedChipIds([])
+    setActiveThemeId(null)
+    setRouteRevealedSegments(0)
+    setActiveStatusFilters([])
+    setSheetState('peek')
+  }
+
   const toggleChip = (id: string) => {
     setActiveSearch(null)
     setSelectedChipIds((prev) => {
-      const next = prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
-      // Auto-promote sheet on first selection
+      const next = prev.includes(id) ? prev.filter((value) => value !== id) : [...prev, id]
       if (prev.length === 0 && next.length > 0 && sheetState === 'peek') {
         setSheetState('half')
       }
@@ -78,96 +358,23 @@ export default function MapPage() {
     if (sheetState === 'peek') setSheetState('half')
   }
 
-  const handlePinTap = (entryId: string) => {
-    navigate(`/entry/${entryId}`)
-  }
-
-  const handleCardTap = (id: string) => {
-    navigate(`/entry/${id}`)
-  }
-
-  const handleChatbotSubmit = async (query: string) => {
-    setActivePlan(null)
-    setRouteRevealedSegments(0)
-    setSelectedChipIds([])
-    setActiveThemeId(null)
-    setActiveSearch(null)
-
-    if (shouldUsePlanMode(query)) {
-      setChatbotLoading(true)
-      const plan = await getPlan(query, 'nkp')
-      setChatbotLoading(false)
-      setActivePlan(plan)
-      setSheetState('full')
-      return
-    }
-
-    const hits = await searchIntentHits('nkp', query, 12, activeStatusFilters).catch(() => [])
-    const byId = new Map(entries.map((e) => [e.id, e]))
-    let rankedResults = hits
-      .map((h) => {
-        const entry = byId.get(h.entryId)
-        if (!entry) return null
-        const matchedReasons = [h.matchedIntent, h.category].filter(
-          (value): value is string => Boolean(value),
-        )
-        if (h.retrievalGrade) matchedReasons.push(`grade:${h.retrievalGrade}`)
-        return {
-          entry,
-          score: Math.round(h.score * 100),
-          matchedReasons,
-        }
-      })
-      .filter((x): x is NonNullable<typeof x> => x !== null)
-
-    // Fallback to deterministic local ranker if backend search is unavailable
-    // or returns no usable mapped results.
-    if (rankedResults.length === 0) {
-      rankedResults = await rankEntriesForIntentWithHints(
-        query,
-        entries,
-        mockIntentClassifierProvider,
-      )
-    }
-
-    if (rankedResults.length > 0) {
-      setActiveSearch({ query, results: rankedResults })
-      setSheetState('full')
-      return
-    }
-
-    // Keep search mode; do not auto-switch to itinerary for normal queries.
-    setActiveSearch({ query, results: [] })
-    setSheetState('full')
-  }
-
-  const handleClearResults = () => {
-    setActiveSearch(null)
-    setActivePlan(null)
-    setSelectedChipIds([])
-    setActiveThemeId(null)
-    setRouteRevealedSegments(0)
-    setActiveStatusFilters([])
-    setSheetState('peek')
-  }
-
   const toggleStatusFilter = (status: 'open_now' | 'closing_soon' | 'closed' | 'unknown') => {
     setActiveStatusFilters((prev) => {
-      const next = prev.includes(status) ? prev.filter((x) => x !== status) : [...prev, status]
+      const next = prev.includes(status) ? prev.filter((value) => value !== status) : [...prev, status]
       if (activeSearch?.query) {
         void searchIntentHits('nkp', activeSearch.query, 12, next).then((hits) => {
-          const byId = new Map(entries.map((e) => [e.id, e]))
+          const byId = new Map(entries.map((entry) => [entry.id, entry]))
           const rankedResults = hits
-            .map((h) => {
-              const entry = byId.get(h.entryId)
+            .map((hit) => {
+              const entry = byId.get(hit.entryId)
               if (!entry) return null
-              const matchedReasons = [h.matchedIntent, h.category].filter(
+              const matchedReasons = [hit.matchedIntent, hit.category].filter(
                 (value): value is string => Boolean(value),
               )
-              if (h.retrievalGrade) matchedReasons.push(`grade:${h.retrievalGrade}`)
-              return { entry, score: Math.round(h.score * 100), matchedReasons }
+              if (hit.retrievalGrade) matchedReasons.push(`grade:${hit.retrievalGrade}`)
+              return { entry, score: Math.round(hit.score * 100), matchedReasons }
             })
-            .filter((x): x is NonNullable<typeof x> => x !== null)
+            .filter((result): result is RankedSearchResult => result !== null)
           setActiveSearch({ query: activeSearch.query, results: rankedResults })
         })
       }
@@ -175,28 +382,22 @@ export default function MapPage() {
     })
   }
 
-  // If we landed on /app?q=<query> (e.g. user typed on Home and submitted),
-  // auto-run the search. Tracked via ref so we only trigger once per query
-  // value, even across the strict-mode double-mount.
   const consumedQueryRef = useRef<string | null>(null)
   useEffect(() => {
-    const q = searchParams.get('q')
-    if (!q) return
-    if (consumedQueryRef.current === q) return
-    consumedQueryRef.current = q
-    void handleChatbotSubmit(q)
-    // Strip the query param from the URL so refresh / back doesn't re-fire
+    const query = searchParams.get('q')
+    if (!query) return
+    if (consumedQueryRef.current === query) return
+    consumedQueryRef.current = query
+    void runConciergeQuery(query, { switchToMap: true })
     setSearchParams({}, { replace: true })
-  // handleChatbotSubmit captures `entries`; we deliberately depend only on q
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams])
 
-  // After plan arrives, reveal route segments in sequence (matches card cascade timing)
   useEffect(() => {
     if (!activePlan) return
     const totalSegments = activePlan.route_geometry.coordinates.length - 1
     setRouteRevealedSegments(0)
-    const startDelay = 600 // wait for rationale to typewriter a bit before drawing
+    const startDelay = 600
     const segmentInterval = 250
     const timers: ReturnType<typeof setTimeout>[] = []
     for (let i = 0; i < totalSegments; i++) {
@@ -207,166 +408,320 @@ export default function MapPage() {
     return () => timers.forEach(clearTimeout)
   }, [activePlan])
 
-  // When a plan is active, use ALL entries (so faded pins still render); otherwise use filtered.
   const searchEntries = activeSearch?.results.map((result) => result.entry) ?? []
   const mapEntries = activePlan ? entries : activeSearch ? searchEntries : filteredEntries
 
   return (
-    <div className="relative w-full h-[100dvh] overflow-hidden">
-      <ChatbotBar
-        onSubmit={handleChatbotSubmit}
-        loading={chatbotLoading}
-        initialQuery={activeSearch?.query ?? activePlan?.query}
-        onClear={handleClearResults}
-        hasPlan={!!activePlan || !!activeSearch}
-      />
-      <MapView
-        city={NKP}
-        entries={mapEntries}
-        onPinTap={(e) => handlePinTap(e.id)}
-        activePlan={activePlan}
-        routeRevealedSegments={routeRevealedSegments}
-      />
+    <div className="relative h-[100dvh] w-full overflow-hidden bg-[#f9fbfe]">
+      <div className="absolute left-4 right-4 top-4 z-kit-overlay">
+        <div
+          role="tablist"
+          aria-label="App mode"
+          className="flex rounded-kit-pill border border-ink/5 bg-white/95 p-1 shadow-kit-pill backdrop-blur"
+        >
+          {[
+            { id: 'chat' as const, label: 'Chat', icon: MessageCircle },
+            { id: 'map' as const, label: 'Map', icon: MapIcon },
+          ].map((tab) => {
+            const active = viewMode === tab.id
+            const Icon = tab.icon
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={() => setViewMode(tab.id)}
+                className={
+                  'flex flex-1 items-center justify-center gap-2 rounded-kit-pill px-4 py-2.5 text-sm font-extrabold transition ' +
+                  (active ? 'bg-kit-gold-1 text-ink' : 'text-ink/65 hover:bg-panel')
+                }
+              >
+                <Icon size={16} aria-hidden="true" />
+                {tab.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
 
-      <BottomSheet state={sheetState} onStateChange={setSheetState}>
-        {activePlan ? (
-          <PlanResult plan={activePlan} onClear={handleClearResults} />
-        ) : activeSearch ? (
-          <div>
-            <div className="flex items-start justify-between gap-3 mb-3">
+      {viewMode === 'map' ? (
+        <>
+          <ChatbotBar
+            className="absolute left-4 right-4 top-20 z-kit-overlay"
+            onSubmit={handleMapSubmit}
+            loading={chatbotLoading}
+            initialQuery={activeSearch?.query ?? activePlan?.query}
+            onClear={handleClearResults}
+            hasPlan={!!activePlan || !!activeSearch}
+          />
+
+          <MapView
+            city={NKP}
+            entries={mapEntries}
+            onPinTap={(entry) => handleCardTap(entry.id)}
+            activePlan={activePlan}
+            routeRevealedSegments={routeRevealedSegments}
+          />
+
+          <BottomSheet state={sheetState} onStateChange={setSheetState}>
+            {activePlan ? (
+              <PlanResult plan={activePlan} onClear={handleClearResults} />
+            ) : activeSearch ? (
               <div>
-                <p className="text-[11px] uppercase tracking-wide text-muted font-semibold">
-                  Search results
-                </p>
-                <h2 className="text-lg font-bold text-ink leading-tight">
-                  {activeSearch.query}
-                </h2>
-                <p className="text-[12px] text-muted mt-0.5">
-                  {activeSearch.results.length} ranked result
-                  {activeSearch.results.length === 1 ? '' : 's'}
+                <div className="mb-3 flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-[11px] font-semibold uppercase tracking-wide text-muted">
+                      Search results
+                    </p>
+                    <h2 className="text-lg font-bold leading-tight text-ink">{activeSearch.query}</h2>
+                    <p className="mt-0.5 text-[12px] text-muted">
+                      {activeSearch.results.length} ranked result
+                      {activeSearch.results.length === 1 ? '' : 's'}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={handleClearResults}
+                    className="text-[12px] font-semibold text-blue-strong hover:text-ink"
+                  >
+                    Clear
+                  </button>
+                </div>
+
+                <div className="mb-2 flex gap-2 overflow-x-auto pb-2">
+                  {[
+                    { id: 'open_now', label: 'Open now' },
+                    { id: 'closing_soon', label: 'Closing soon' },
+                    { id: 'closed', label: 'Closed' },
+                    { id: 'unknown', label: 'Uncertain' },
+                  ].map((statusOption) => {
+                    const active = activeStatusFilters.includes(
+                      statusOption.id as 'open_now' | 'closing_soon' | 'closed' | 'unknown',
+                    )
+                    return (
+                      <button
+                        key={statusOption.id}
+                        type="button"
+                        onClick={() =>
+                          toggleStatusFilter(
+                            statusOption.id as 'open_now' | 'closing_soon' | 'closed' | 'unknown',
+                          )
+                        }
+                        className={'kit-chip ' + (active ? 'kit-chip-active' : 'kit-chip-inactive')}
+                      >
+                        {statusOption.label}
+                      </button>
+                    )
+                  })}
+                </div>
+
+                {activeSearch.results.length === 0 && (
+                  <div className="rounded-kit-photo border border-dashed border-ink/10 bg-panel px-4 py-6 text-sm text-muted">
+                    No ranked matches yet. Try a different phrasing or switch back to Chat for another follow-up.
+                  </div>
+                )}
+
+                {activeSearch.results.map((result, index) => (
+                  <div key={result.entry.id} className="mb-3">
+                    <div className="mb-1 flex items-center gap-2 text-[11px] text-muted">
+                      <span className="font-bold text-blue-strong">#{index + 1}</span>
+                      <span>{result.score} pts</span>
+                      {result.matchedReasons.length > 0 && (
+                        <span className="truncate">{result.matchedReasons.join(' / ')}</span>
+                      )}
+                    </div>
+                    <EntryCard
+                      entry={result.entry}
+                      distanceKm={distanceKm(
+                        { lat: NKP.default_lat, lng: NKP.default_lng },
+                        { lat: result.entry.lat, lng: result.entry.lng },
+                      )}
+                      onTap={(entry) => handleCardTap(entry.id)}
+                    />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <>
+                <ThemeStrip
+                  themes={themes}
+                  activeThemeId={activeThemeId}
+                  onThemeTap={handleThemeTap}
+                />
+
+                <div className="scrollbar-none -mx-4 flex gap-2 overflow-x-auto px-4 pb-3">
+                  {CHIPS.map((chip) => {
+                    const active = selectedChipIds.includes(chip.id)
+                    return (
+                      <button
+                        key={chip.id}
+                        onClick={() => toggleChip(chip.id)}
+                        className={'kit-chip ' + (active ? 'kit-chip-active' : 'kit-chip-inactive')}
+                      >
+                        {chip.label}
+                      </button>
+                    )
+                  })}
+                </div>
+
+                {activeTheme && (
+                  <div
+                    className="mb-3 flex items-center gap-2.5 rounded-kit-photo border-2 p-3 text-[12px]"
+                    style={{
+                      background: `linear-gradient(135deg, ${activeTheme.accent_color}25, ${activeTheme.accent_color}08)`,
+                      borderColor: `${activeTheme.accent_color}50`,
+                    }}
+                  >
+                    <span className="text-lg">{activeTheme.emoji}</span>
+                    <span className="flex-1 font-semibold text-ink/85">
+                      Showing <span className="font-extrabold">{activeTheme.name_en}</span>
+                    </span>
+                    <button
+                      onClick={() => setActiveThemeId(null)}
+                      className="grid h-7 w-7 place-items-center rounded-kit-pill text-base leading-none text-muted transition hover:bg-ink/5 hover:text-ink"
+                      aria-label="Clear theme"
+                    >
+                      x
+                    </button>
+                  </div>
+                )}
+
+                <div>
+                  {filteredEntries.length === 0 && (
+                    <div className="py-8 text-center text-sm text-muted">
+                      No matches. Try removing a filter.
+                    </div>
+                  )}
+                  {filteredEntries.map((entry) => (
+                    <EntryCard
+                      key={entry.id}
+                      entry={entry}
+                      distanceKm={distanceKm(
+                        { lat: NKP.default_lat, lng: NKP.default_lng },
+                        { lat: entry.lat, lng: entry.lng },
+                      )}
+                      onTap={(nextEntry) => handleCardTap(nextEntry.id)}
+                    />
+                  ))}
+                </div>
+              </>
+            )}
+          </BottomSheet>
+        </>
+      ) : (
+        <div className="flex h-full flex-col pt-20">
+          <div className="px-4 pb-4 pt-3">
+            <p className="kit-eyebrow mb-2">Nakhon Phanom</p>
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h1 className="text-[28px] font-black tracking-[-0.06em] text-ink">Concierge</h1>
+                <p className="mt-1 max-w-[24rem] text-sm text-muted">
+                  Ask for blessings, local food, quiet nature, photo spots, or let me build a day route for you.
                 </p>
               </div>
               <button
                 type="button"
-                onClick={handleClearResults}
-                className="text-[12px] font-semibold text-blue-strong hover:text-ink"
+                onClick={() => setPlanSheetOpen(true)}
+                className="shrink-0 rounded-kit-pill bg-kit-gold-1 px-4 py-3 text-sm font-extrabold text-ink shadow-kit-pill transition hover:brightness-[0.98]"
               >
-                Clear
+                Plan my day
               </button>
             </div>
-            <div className="flex gap-2 overflow-x-auto pb-2 mb-2">
-              {[
-                { id: 'open_now', label: 'Open now' },
-                { id: 'closing_soon', label: 'Closing soon' },
-                { id: 'closed', label: 'Closed' },
-                { id: 'unknown', label: 'Uncertain' },
-              ].map((s) => {
-                const active = activeStatusFilters.includes(s.id as 'open_now' | 'closing_soon' | 'closed' | 'unknown')
-                return (
-                  <button
-                    key={s.id}
-                    type="button"
-                    onClick={() => toggleStatusFilter(s.id as 'open_now' | 'closing_soon' | 'closed' | 'unknown')}
-                    className={'kit-chip ' + (active ? 'kit-chip-active' : 'kit-chip-inactive')}
-                  >
-                    {s.label}
-                  </button>
-                )
-              })}
-            </div>
+          </div>
 
-            {activeSearch.results.map((result, index) => (
-              <div key={result.entry.id} className="mb-3">
-                <div className="flex items-center gap-2 mb-1 text-[11px] text-muted">
-                  <span className="font-bold text-blue-strong">#{index + 1}</span>
-                  <span>{result.score} pts</span>
-                  {result.matchedReasons.length > 0 && (
-                    <span className="truncate">{result.matchedReasons.join(' · ')}</span>
-                  )}
-                </div>
-                <EntryCard
-                  entry={result.entry}
-                  distanceKm={distanceKm(
-                    { lat: NKP.default_lat, lng: NKP.default_lng },
-                    { lat: result.entry.lat, lng: result.entry.lng },
-                  )}
-                  onTap={(e) => handleCardTap(e.id)}
-                />
+          <div ref={chatScrollRef} className="flex-1 space-y-3 overflow-y-auto px-4 pb-32">
+            {chatMessages.map((message) => (
+              <div key={message.id} className="space-y-2">
+                <ChatBubble role={message.role}>
+                  <p className="leading-relaxed">{message.text}</p>
+                </ChatBubble>
+
+                {message.role === 'assistant' && message.results && message.results.length > 0 && (
+                  <div className="space-y-2 pl-1 pr-7">
+                    <p className="text-[11px] font-extrabold uppercase tracking-[0.18em] text-kit-eyebrow">
+                      Top matches
+                    </p>
+                    {message.results.map((result) => (
+                      <ChatResultCard
+                        key={`${message.id}-${result.entry.id}`}
+                        entry={result.entry}
+                        score={result.score}
+                        matchedReasons={result.matchedReasons}
+                        onTap={(entry) => handleCardTap(entry.id)}
+                      />
+                    ))}
+                  </div>
+                )}
+
+                {message.role === 'assistant' && message.plan && (
+                  <div className="pl-1 pr-7">
+                    <ChatPlanCard plan={message.plan} onOpenEntry={handleCardTap} />
+                  </div>
+                )}
               </div>
             ))}
+
+            {chatThinking && (
+              <ChatBubble role="assistant">
+                <div className="flex items-center gap-2 text-sm font-medium text-muted">
+                  <LoaderCircle size={16} className="animate-spin text-blue-strong" aria-hidden="true" />
+                  Thinking...
+                </div>
+              </ChatBubble>
+            )}
           </div>
-        ) : (
-          <>
-            {/* Theme strip — city identity (above chips) */}
-            <ThemeStrip
-              themes={themes}
-              activeThemeId={activeThemeId}
-              onThemeTap={handleThemeTap}
-            />
 
-            {/* Filter chips */}
-            <div className="flex gap-2 overflow-x-auto pb-3 -mx-4 px-4 scrollbar-none">
-              {CHIPS.map((chip) => {
-                const active = selectedChipIds.includes(chip.id)
-                return (
-                  <button
-                    key={chip.id}
-                    onClick={() => toggleChip(chip.id)}
-                    className={
-                      'kit-chip ' + (active ? 'kit-chip-active' : 'kit-chip-inactive')
-                    }
-                  >
-                    {chip.label}
-                  </button>
-                )
-              })}
-            </div>
-
-            {/* Active-theme banner */}
-            {activeTheme && (
-              <div
-                className="rounded-kit-photo p-3 mb-3 text-[12px] flex items-center gap-2.5 border-2"
-                style={{
-                  background: `linear-gradient(135deg, ${activeTheme.accent_color}25, ${activeTheme.accent_color}08)`,
-                  borderColor: `${activeTheme.accent_color}50`,
-                }}
-              >
-                <span className="text-lg">{activeTheme.emoji}</span>
-                <span className="flex-1 text-ink/85 font-semibold">
-                  Showing <span className="font-extrabold">{activeTheme.name_en}</span>
-                </span>
+          <div className="absolute inset-x-0 bottom-16 px-4">
+            <form
+              onSubmit={(event) => {
+                event.preventDefault()
+                if (!chatbotLoading && chatDraft.trim()) {
+                  void handleChatSubmit(chatDraft)
+                }
+              }}
+              className="rounded-[28px] border border-ink/5 bg-white p-3 shadow-kit-pill"
+            >
+              <label htmlFor="chat-follow-up" className="sr-only">
+                Follow up
+              </label>
+              <div className="flex items-center gap-2">
+                <Sparkles size={16} className="shrink-0 text-blue-strong" aria-hidden="true" />
+                <input
+                  id="chat-follow-up"
+                  type="text"
+                  autoComplete="off"
+                  value={chatDraft}
+                  onChange={(event) => setChatDraft(event.target.value)}
+                  placeholder="Follow up..."
+                  disabled={chatbotLoading}
+                  className="min-w-0 flex-1 bg-transparent text-sm font-semibold text-ink outline-none placeholder:text-muted disabled:opacity-60"
+                />
                 <button
-                  onClick={() => setActiveThemeId(null)}
-                  className="w-7 h-7 grid place-items-center rounded-kit-pill text-muted hover:text-ink hover:bg-ink/5 text-base leading-none transition"
-                  aria-label="Clear theme"
+                  type="submit"
+                  disabled={chatbotLoading || chatDraft.trim().length === 0}
+                  className="grid h-11 w-11 place-items-center rounded-kit-pill bg-ink text-white transition hover:bg-ink/90 disabled:opacity-40"
+                  aria-label="Send chat message"
                 >
-                  ✕
+                  <ChevronRight size={18} aria-hidden="true" />
                 </button>
               </div>
-            )}
+            </form>
+          </div>
 
-            {/* Card list (filtered) */}
-            <div>
-              {filteredEntries.length === 0 && (
-                <div className="text-center text-sm text-muted py-8">
-                  No matches. Try removing a filter.
-                </div>
-              )}
-              {filteredEntries.map((entry) => (
-                <EntryCard
-                  key={entry.id}
-                  entry={entry}
-                  distanceKm={distanceKm(
-                    { lat: NKP.default_lat, lng: NKP.default_lng },
-                    { lat: entry.lat, lng: entry.lng },
-                  )}
-                  onTap={(e) => handleCardTap(e.id)}
-                />
-              ))}
-            </div>
-          </>
-        )}
-      </BottomSheet>
+          <PlanMyDaySheet
+            open={planSheetOpen}
+            selections={planSelections}
+            onChange={setPlanSelections}
+            onClose={() => setPlanSheetOpen(false)}
+            onSubmit={() => {
+              void handlePlanMyDay()
+            }}
+            loading={chatbotLoading}
+          />
+        </div>
+      )}
+
       <KitBottomNav2 active="grid" />
     </div>
   )

--- a/tests/e2e/mvp-smoke.spec.ts
+++ b/tests/e2e/mvp-smoke.spec.ts
@@ -1,42 +1,50 @@
 import { expect, test } from 'playwright/test'
 
 test.describe('frontend MVP smoke', () => {
-  test('home and map routes load', async ({ page }) => {
+  test('home loads and app toggles between chat and map', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded' })
     await expect(
       page.getByRole('heading', { name: 'Ready to Explore', exact: false }),
     ).toBeVisible()
 
     await page.goto('/app', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByRole('heading', { name: 'Concierge' })).toBeVisible()
+    await expect(
+      page.getByText('Ask me about blessings, food, nature, photo spots, or trip planning'),
+    ).toBeVisible()
+
+    await page.getByRole('tab', { name: 'Map' }).click()
     await expect(page.getByRole('search')).toBeVisible()
     await expect(page.getByLabel('Ask about Nakhon Phanom')).toBeVisible()
   })
 
-  test('intent search returns ranked results and can be cleared', async ({ page }) => {
+  test('chat search shows assistant results and map keeps them accessible', async ({ page }) => {
     await page.goto('/app', { waitUntil: 'domcontentloaded' })
 
-    const searchInput = page.getByLabel('Ask about Nakhon Phanom')
-    await searchInput.fill('ไหว้พระ ขอพร')
-    await page.getByRole('button', { name: 'Submit' }).click()
+    const followUpInput = page.getByLabel('Follow up')
+    await followUpInput.fill('ไหว้พระ ขอพร')
+    await page.getByRole('button', { name: 'Send chat message' }).click()
 
+    await expect(page.getByText('Top matches')).toBeVisible()
+    await expect(page.getByRole('button', { name: /Wat Phra That Phanom/i }).first()).toBeVisible()
+
+    await page.getByRole('tab', { name: 'Map' }).click()
     await expect(page.getByText('Search results')).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'ไหว้พระ ขอพร' })).toBeVisible()
-    await expect(page.getByText('Wat Phra That Phanom')).toBeVisible()
-
-    await page.getByRole('button', { name: 'Clear search or plan' }).click()
-    await expect(searchInput).toHaveValue('')
-    await expect(page.getByText('Search results')).not.toBeVisible()
+    await expect(page.getByRole('button', { name: /Wat Phra That Phanom/i }).first()).toBeVisible()
   })
 
-  test('plan-style prompt shows a plan without crashing', async ({ page }) => {
+  test('plan my day sheet creates a plan and keeps map accessible', async ({ page }) => {
     await page.goto('/app', { waitUntil: 'domcontentloaded' })
 
-    const searchInput = page.getByLabel('Ask about Nakhon Phanom')
-    await searchInput.fill('I have one afternoon, I love food and history')
-    await page.getByRole('button', { name: 'Submit' }).click()
+    await page.getByRole('button', { name: 'Plan my day' }).click()
+    await expect(page.getByRole('heading', { name: 'Plan my day' })).toBeVisible()
+    await page.getByRole('button', { name: 'Food' }).click()
+    await page.getByRole('button', { name: 'Create plan' }).click()
 
-    await expect(page.getByText('Your plan', { exact: false })).toBeVisible()
+    await expect(page.getByText('Your plan')).toBeVisible()
     await expect(page.getByText('Pho Sawan')).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Clear search or plan' })).toBeVisible()
+
+    await page.getByRole('tab', { name: 'Map' }).click()
+    await expect(page.getByRole('search')).toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary

Adds a mobile-first concierge chat MVP on top of the existing search and planning engines.

## What changed

- Added a Chat / Map segmented experience on `/app`
- Added a chat-first concierge view with:
  - user and assistant bubbles
  - initial assistant guidance
  - bottom follow-up composer
  - loading/thinking state
- Added compact chat result cards for search responses
- Added a Plan my day bottom sheet with:
  - duration options
  - vibe options
  - pace options
- Reused existing backend search and plan flows:
  - `searchIntentHits()`
  - `getPlan()`
  - existing deterministic fallback behavior
- Kept the existing Map tab and map/search result flow available
- Updated Playwright smoke coverage for the chat MVP

## Scope

- Frontend-only
- No backend changes
- No new dependencies
- No secrets or env changes
- Existing backend API flow remains unchanged

## Verification

- `npm.cmd test`
- `npm.cmd run build`
- `npm.cmd run test:e2e -- --reporter=list`
- `git diff --check`

## Manual QA checklist

- `/app` opens in Chat mode
- Sending `ขอลูก` shows assistant response and ranked result cards
- `Plan my day` opens the planner sheet
- Planner selections generate an itinerary
- Map tab remains usable
- Search results still work in Map mode
- DevTools Network still shows backend requests returning 200