### PR TITLE
fix: reduce concierge chat hallucinations

### DIFF
--- a/src/components/ChatResultCard.tsx
+++ b/src/components/ChatResultCard.tsx
@@ -1,4 +1,6 @@
 import { ChevronRight } from 'lucide-react'
+import type { ChatLanguage } from '../lib/chatGuard'
+import { simplifyChatLabels } from '../lib/chatLabels'
 import { isOpenNow } from '../lib/status'
 import { STATUS_COLOR, STATUS_LABEL } from '../lib/statusDisplay'
 import type { Entry } from '../types'
@@ -7,11 +9,19 @@ type Props = {
   entry: Entry
   score: number
   matchedReasons: string[]
+  language?: ChatLanguage
   onTap?: (entry: Entry) => void
 }
 
-export default function ChatResultCard({ entry, score, matchedReasons, onTap }: Props) {
+export default function ChatResultCard({
+  entry,
+  score,
+  matchedReasons,
+  language = 'en',
+  onTap,
+}: Props) {
   const status = isOpenNow(entry, new Date())
+  const labels = simplifyChatLabels(matchedReasons, language)
 
   return (
     <button
@@ -49,9 +59,9 @@ export default function ChatResultCard({ entry, score, matchedReasons, onTap }: 
             <span className="text-ink/20">/</span>
             <span className="capitalize">{entry.category}</span>
           </div>
-          {matchedReasons.length > 0 && (
+          {labels.length > 0 && (
             <div className="mt-2 flex flex-wrap gap-1.5">
-              {matchedReasons.slice(0, 3).map((reason) => (
+              {labels.map((reason) => (
                 <span
                   key={reason}
                   className="rounded-kit-pill bg-panel px-2 py-1 text-[10px] font-bold text-ink/70"

--- a/src/lib/chatGuard.test.ts
+++ b/src/lib/chatGuard.test.ts
@@ -68,4 +68,10 @@ describe('classifyChatIntent', () => {
     expect(classifyChatIntent('temple').travelHint).toBe('blessing')
     expect(classifyChatIntent('food').travelHint).toBe('food')
   })
+
+  it('uses bounded matching for Latin keywords', () => {
+    expect(classifyChatIntent('templeton review').intent).not.toBe('travel_search')
+    expect(classifyChatIntent('breakfasting tips').travelHint).not.toBe('food')
+    expect(classifyChatIntent('hidden gemstone market').travelHint).not.toBe('hidden_gem')
+  })
 })

--- a/src/lib/chatGuard.test.ts
+++ b/src/lib/chatGuard.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { classifyChatIntent } from './chatGuard'
+
+describe('classifyChatIntent', () => {
+  it('marks chicken and egg as off-topic', () => {
+    const result = classifyChatIntent('ไก่กับไข่อะไรเกิดก่อน')
+    expect(result.intent).toBe('off_topic')
+    expect(result.intent).not.toBe('travel_search')
+  })
+
+  it('marks pause phrases in Thai', () => {
+    expect(classifyChatIntent('เดียวนะ').intent).toBe('pause')
+    expect(classifyChatIntent('เดี๋ยวนะ').intent).toBe('pause')
+    expect(classifyChatIntent('รอก่อน').intent).toBe('pause')
+  })
+
+  it('marks date question as off-topic', () => {
+    expect(classifyChatIntent('วันนี้วันอะไร').intent).toBe('off_topic')
+  })
+
+  it('marks coding request as off-topic', () => {
+    expect(classifyChatIntent('เขียนโค้ด python ให้หน่อย').intent).toBe('off_topic')
+  })
+
+  it('marks very short Thai prompts as unclear', () => {
+    expect(classifyChatIntent('เอา').intent).toBe('unclear')
+    expect(classifyChatIntent('อะไร').intent).toBe('unclear')
+  })
+
+  it('treats ขอลูก as blessing travel search', () => {
+    const result = classifyChatIntent('ขอลูก')
+    expect(result.intent).toBe('travel_search')
+    expect(result.travelHint).toBe('blessing')
+  })
+
+  it('treats blessing search as travel search', () => {
+    const result = classifyChatIntent('ไหว้พระ ขอพร')
+    expect(result.intent).toBe('travel_search')
+    expect(result.travelHint).toBe('blessing')
+  })
+
+  it('treats food-style Thai requests as travel search', () => {
+    expect(classifyChatIntent('อยากกินของอร่อย').travelHint).toBe('food')
+    expect(classifyChatIntent('ร้านอาหารเวียดนาม').travelHint).toBe('food')
+  })
+
+  it('treats cafe and riverside searches as travel search', () => {
+    const result = classifyChatIntent('คาเฟ่ริมโขง')
+    expect(result.intent).toBe('travel_search')
+    expect(['cafe', 'general']).toContain(result.travelHint)
+  })
+
+  it('treats nature and photo requests as travel search', () => {
+    expect(classifyChatIntent('ที่เที่ยวธรรมชาติ').travelHint).toBe('nature')
+    expect(classifyChatIntent('จุดถ่ายรูป').travelHint).toBe('photo')
+  })
+
+  it('treats trip planning phrases as travel plan', () => {
+    expect(classifyChatIntent('วางแผนเที่ยวครึ่งวัน').intent).toBe('travel_plan')
+    expect(classifyChatIntent('เที่ยว 1 วัน').intent).toBe('travel_plan')
+    expect(classifyChatIntent('I have one afternoon').intent).toBe('travel_plan')
+  })
+
+  it('treats English travel search and pause phrases correctly', () => {
+    expect(classifyChatIntent('food near Mekong').intent).toBe('travel_search')
+    expect(classifyChatIntent('hold on').intent).toBe('pause')
+    expect(classifyChatIntent('hidden gem').travelHint).toBe('hidden_gem')
+    expect(classifyChatIntent('temple').travelHint).toBe('blessing')
+    expect(classifyChatIntent('food').travelHint).toBe('food')
+  })
+})

--- a/src/lib/chatGuard.ts
+++ b/src/lib/chatGuard.ts
@@ -30,6 +30,8 @@ type KeywordGroup = {
   keywords: string[]
 }
 
+const LATIN_WORD_PATTERN = /[a-z]/
+
 const PAUSE_PATTERNS = [
   'เดี๋ยวนะ',
   'เดียวนะ',
@@ -150,12 +152,28 @@ function detectLanguage(query: string): ChatLanguage {
 }
 
 function includesPattern(query: string, patterns: string[]): string | null {
-  return patterns.find((pattern) => query.includes(normalizeQuery(pattern))) ?? null
+  return (
+    patterns.find((pattern) => matchesNormalizedPattern(query, normalizeQuery(pattern))) ?? null
+  )
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function matchesNormalizedPattern(query: string, pattern: string): boolean {
+  if (!pattern) return false
+  if (!LATIN_WORD_PATTERN.test(pattern)) {
+    return query.includes(pattern)
+  }
+
+  const boundedPattern = new RegExp(`(^|[^a-z0-9])${escapeRegex(pattern)}($|[^a-z0-9])`)
+  return boundedPattern.test(query)
 }
 
 function detectTravelHint(query: string): TravelHint | undefined {
   for (const group of TRAVEL_KEYWORD_GROUPS) {
-    if (group.keywords.some((keyword) => query.includes(normalizeQuery(keyword)))) {
+    if (group.keywords.some((keyword) => matchesNormalizedPattern(query, normalizeQuery(keyword)))) {
       return group.hint
     }
   }

--- a/src/lib/chatGuard.ts
+++ b/src/lib/chatGuard.ts
@@ -1,0 +1,236 @@
+export type ChatIntent =
+  | 'travel_search'
+  | 'travel_plan'
+  | 'pause'
+  | 'off_topic'
+  | 'unclear'
+
+export type ChatLanguage = 'th' | 'en'
+
+export type TravelHint =
+  | 'blessing'
+  | 'food'
+  | 'cafe'
+  | 'nature'
+  | 'photo'
+  | 'family'
+  | 'hidden_gem'
+  | 'general'
+
+export type ChatGuardResult = {
+  intent: ChatIntent
+  language: ChatLanguage
+  normalizedQuery: string
+  travelHint?: TravelHint
+  reason: string
+}
+
+type KeywordGroup = {
+  hint: TravelHint
+  keywords: string[]
+}
+
+const PAUSE_PATTERNS = [
+  'เดี๋ยวนะ',
+  'เดียวนะ',
+  'รอก่อน',
+  'แป๊บ',
+  'แปป',
+  'wait',
+  'hold on',
+  'hmm',
+]
+
+const OFF_TOPIC_PATTERNS = [
+  'ไก่กับไข่อะไรเกิดก่อน',
+  'วันนี้วันอะไร',
+  'เขียนโค้ด python ให้หน่อย',
+  'python',
+  'หวยออกอะไร',
+  'เล่าเรื่องตลกให้ฟัง',
+  'joke',
+  'what day is it',
+]
+
+const PLAN_PATTERNS = [
+  'วางแผนเที่ยว',
+  'วางแผน',
+  'ครึ่งวัน',
+  '1 วัน',
+  '1วัน',
+  'หนึ่งวัน',
+  'จัดทริป',
+  'จัดแพลน',
+  'เที่ยว 1 วัน',
+  'เที่ยว1วัน',
+  'plan my day',
+  'trip plan',
+  'itinerary',
+  'i have one afternoon',
+  'one afternoon',
+  'half day',
+  'one day',
+]
+
+const AMBIGUOUS_SHORT_MESSAGES = [
+  'เอา',
+  'อะไร',
+  'ยังไง',
+  'ต่อ',
+  'ดีไหม',
+]
+
+const TRAVEL_KEYWORD_GROUPS: KeywordGroup[] = [
+  {
+    hint: 'blessing',
+    keywords: [
+      'ขอลูก',
+      'ไหว้พระ',
+      'ขอพร',
+      'สายบุญ',
+      'วัด',
+      'temple',
+      'blessing',
+      'fertility',
+      'merit',
+      'spiritual',
+    ],
+  },
+  {
+    hint: 'food',
+    keywords: [
+      'ของอร่อย',
+      'ร้านอาหาร',
+      'อาหารเวียดนาม',
+      'อาหารเช้า',
+      'ของกิน',
+      'กินอะไร',
+      'food',
+      'restaurant',
+      'breakfast',
+      'vietnamese',
+    ],
+  },
+  {
+    hint: 'cafe',
+    keywords: ['คาเฟ่', 'กาแฟ', 'cafe', 'coffee'],
+  },
+  {
+    hint: 'nature',
+    keywords: ['ธรรมชาติ', 'แม่น้ำ', 'ภูเขา', 'nature', 'park'],
+  },
+  {
+    hint: 'photo',
+    keywords: ['ถ่ายรูป', 'จุดถ่ายรูป', 'วิวสวย', 'photo', 'photospot', 'photo spot'],
+  },
+  {
+    hint: 'family',
+    keywords: ['ครอบครัว', 'เด็ก', 'family'],
+  },
+  {
+    hint: 'hidden_gem',
+    keywords: ['hidden gem', 'ลับ', 'คนไม่เยอะ', 'ไม่แมส'],
+  },
+  {
+    hint: 'general',
+    keywords: ['เที่ยว', 'ที่เที่ยว', 'mekong', 'ริมโขง', 'riverside', 'นครพนม', 'nakhon phanom'],
+  },
+]
+
+function normalizeQuery(value: string): string {
+  return value
+    .trim()
+    .toLocaleLowerCase()
+    .normalize('NFKC')
+    .replace(/\s+/g, ' ')
+}
+
+function detectLanguage(query: string): ChatLanguage {
+  return /[\u0E00-\u0E7F]/.test(query) ? 'th' : 'en'
+}
+
+function includesPattern(query: string, patterns: string[]): string | null {
+  return patterns.find((pattern) => query.includes(normalizeQuery(pattern))) ?? null
+}
+
+function detectTravelHint(query: string): TravelHint | undefined {
+  for (const group of TRAVEL_KEYWORD_GROUPS) {
+    if (group.keywords.some((keyword) => query.includes(normalizeQuery(keyword)))) {
+      return group.hint
+    }
+  }
+  return undefined
+}
+
+export function classifyChatIntent(query: string): ChatGuardResult {
+  const normalizedQuery = normalizeQuery(query)
+  const language = detectLanguage(normalizedQuery)
+
+  if (!normalizedQuery) {
+    return {
+      intent: 'unclear',
+      language,
+      normalizedQuery,
+      reason: 'empty query',
+    }
+  }
+
+  const pauseMatch = includesPattern(normalizedQuery, PAUSE_PATTERNS)
+  if (pauseMatch) {
+    return {
+      intent: 'pause',
+      language,
+      normalizedQuery,
+      reason: `pause phrase: ${pauseMatch}`,
+    }
+  }
+
+  const offTopicMatch = includesPattern(normalizedQuery, OFF_TOPIC_PATTERNS)
+  if (offTopicMatch) {
+    return {
+      intent: 'off_topic',
+      language,
+      normalizedQuery,
+      reason: `off-topic phrase: ${offTopicMatch}`,
+    }
+  }
+
+  const planMatch = includesPattern(normalizedQuery, PLAN_PATTERNS)
+  if (planMatch) {
+    return {
+      intent: 'travel_plan',
+      language,
+      normalizedQuery,
+      travelHint: 'general',
+      reason: `plan phrase: ${planMatch}`,
+    }
+  }
+
+  const travelHint = detectTravelHint(normalizedQuery)
+  if (travelHint) {
+    return {
+      intent: 'travel_search',
+      language,
+      normalizedQuery,
+      travelHint,
+      reason: `travel keyword for ${travelHint}`,
+    }
+  }
+
+  const shortMatch = includesPattern(normalizedQuery, AMBIGUOUS_SHORT_MESSAGES)
+  if (shortMatch || normalizedQuery.length <= 8) {
+    return {
+      intent: 'unclear',
+      language,
+      normalizedQuery,
+      reason: shortMatch ? `ambiguous short phrase: ${shortMatch}` : 'short ambiguous query',
+    }
+  }
+
+  return {
+    intent: 'off_topic',
+    language,
+    normalizedQuery,
+    reason: 'no travel signal detected',
+  }
+}

--- a/src/lib/chatLabels.test.ts
+++ b/src/lib/chatLabels.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { simplifyChatLabels } from './chatLabels'
+
+describe('simplifyChatLabels', () => {
+  it('removes internal labels and keeps user-facing food label', () => {
+    const result = simplifyChatLabels(
+      ['general_discovery', 'food_trip', 'grade:medium', 'food'],
+      'en',
+    )
+    expect(result.join(' ')).not.toContain('general_discovery')
+    expect(result.join(' ')).not.toContain('food_trip')
+    expect(result.join(' ')).not.toContain('grade:medium')
+    expect(result).toContain('Food')
+  })
+
+  it('keeps user-facing temple or blessing labels without grade', () => {
+    const result = simplifyChatLabels(['temple', 'spiritual', 'grade:high'], 'en')
+    expect(result.join(' ')).not.toContain('grade:high')
+    expect(result.some((label) => label === 'Temple' || label === 'Blessing')).toBe(true)
+  })
+
+  it('does not display snake_case labels raw', () => {
+    const result = simplifyChatLabels(['temple_category', 'general_discovery', 'photo_spot'], 'th')
+    expect(result.join(' ')).not.toContain('temple_category')
+    expect(result.join(' ')).not.toContain('general_discovery')
+    expect(result.some((label) => label === 'ถ่ายรูป' || label === 'วัด')).toBe(true)
+  })
+})

--- a/src/lib/chatLabels.ts
+++ b/src/lib/chatLabels.ts
@@ -1,0 +1,62 @@
+import type { ChatLanguage } from './chatGuard'
+
+const LABEL_MAP: Array<{ keys: string[]; th: string; en: string }> = [
+  { keys: ['blessing', 'fertility', 'merit', 'spiritual', 'pray'], th: 'ขอพร', en: 'Blessing' },
+  { keys: ['temple'], th: 'วัด', en: 'Temple' },
+  { keys: ['food', 'restaurant', 'vietnamese'], th: 'อาหาร', en: 'Food' },
+  { keys: ['cafe', 'coffee'], th: 'คาเฟ่', en: 'Cafe' },
+  { keys: ['nature', 'park'], th: 'ธรรมชาติ', en: 'Nature' },
+  { keys: ['landmark'], th: 'แลนด์มาร์ก', en: 'Landmark' },
+  { keys: ['photo'], th: 'ถ่ายรูป', en: 'Photo spot' },
+  { keys: ['riverside', 'mekong'], th: 'ริมโขง', en: 'Riverside' },
+]
+
+function normalizeLabel(value: string): string {
+  return value
+    .trim()
+    .toLocaleLowerCase()
+    .normalize('NFKC')
+}
+
+function shouldDropRawLabel(label: string): boolean {
+  if (!label) return true
+  if (label.startsWith('grade:')) return true
+  if (label.startsWith('ai ')) return true
+  if (label.includes('general_discovery')) return false
+  if (label.includes('food_trip')) return false
+  if (/[a-z]+_[a-z]+/.test(label)) return false
+  return false
+}
+
+export function simplifyChatLabels(rawLabels: string[], language: ChatLanguage): string[] {
+  const simplified: string[] = []
+
+  for (const rawLabel of rawLabels) {
+    const normalized = normalizeLabel(rawLabel)
+    if (!normalized) continue
+    if (normalized.startsWith('grade:') || normalized.startsWith('ai ')) continue
+
+    const tokens = normalized
+      .split(/[^a-z]+/)
+      .map((token) => token.trim())
+      .filter(Boolean)
+
+    for (const mapping of LABEL_MAP) {
+      if (tokens.some((token) => mapping.keys.includes(token))) {
+        const display = language === 'th' ? mapping.th : mapping.en
+        if (!simplified.includes(display)) {
+          simplified.push(display)
+        }
+        break
+      }
+    }
+
+    if (simplified.length >= 3) break
+
+    if (!shouldDropRawLabel(normalized) && !/[a-z]+_[a-z]+/.test(normalized)) {
+      continue
+    }
+  }
+
+  return simplified.slice(0, 3)
+}

--- a/src/lib/chatResponsePolicy.test.ts
+++ b/src/lib/chatResponsePolicy.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import type { ChatGuardResult } from './chatGuard'
+import { decideChatResponse } from './chatResponsePolicy'
+
+function guard(overrides: Partial<ChatGuardResult>): ChatGuardResult {
+  return {
+    intent: 'travel_search',
+    language: 'th',
+    normalizedQuery: 'query',
+    reason: 'test',
+    ...overrides,
+  }
+}
+
+describe('decideChatResponse', () => {
+  it('returns Thai off-topic guidance with no cards', () => {
+    const result = decideChatResponse({
+      guard: guard({ intent: 'off_topic', language: 'th' }),
+      searchResultCount: 0,
+      topScore: 0,
+    })
+    expect(result.shouldShowCards).toBe(false)
+    expect(result.text).toContain('ช่วยเรื่องเที่ยวนครพนมเป็นหลัก')
+  })
+
+  it('returns Thai pause response with no cards', () => {
+    const result = decideChatResponse({
+      guard: guard({ intent: 'pause', language: 'th' }),
+      searchResultCount: 0,
+      topScore: 0,
+    })
+    expect(result.shouldShowCards).toBe(false)
+    expect(result.text).toContain('พิมพ์ต่อได้เลย')
+  })
+
+  it('returns Thai clarification for unclear intent', () => {
+    const result = decideChatResponse({
+      guard: guard({ intent: 'unclear', language: 'th' }),
+      searchResultCount: 0,
+      topScore: 0,
+    })
+    expect(result.shouldShowCards).toBe(false)
+    expect(result.text).toContain('ผมยังไม่แน่ใจ')
+  })
+
+  it('returns tentative blessing wording with cards for medium confidence', () => {
+    const result = decideChatResponse({
+      guard: guard({ language: 'th', travelHint: 'blessing' }),
+      searchResultCount: 3,
+      topScore: 60,
+    })
+    expect(result.confidence).toBe('medium')
+    expect(result.shouldShowCards).toBe(true)
+    expect(result.text).toContain('สถานที่ขอพรเรื่องบุตรหรือสายบุญ')
+  })
+
+  it('returns grounded high-confidence wording for strong matches', () => {
+    const result = decideChatResponse({
+      guard: guard({ language: 'th', travelHint: 'food' }),
+      searchResultCount: 4,
+      topScore: 82,
+    })
+    expect(result.confidence).toBe('high')
+    expect(result.shouldShowCards).toBe(true)
+    expect(result.text).toContain('ตรงกับคำขอของคุณ')
+    expect(result.text).not.toContain('strong match')
+  })
+
+  it('returns clarification and no cards for low confidence without hint', () => {
+    const result = decideChatResponse({
+      guard: guard({ language: 'th', travelHint: undefined }),
+      searchResultCount: 2,
+      topScore: 22,
+    })
+    expect(result.confidence).toBe('low')
+    expect(result.shouldShowCards).toBe(false)
+    expect(result.text).toContain('ผมยังไม่แน่ใจ')
+  })
+
+  it('returns English guidance for off-topic queries', () => {
+    const result = decideChatResponse({
+      guard: guard({ intent: 'off_topic', language: 'en' }),
+      searchResultCount: 0,
+      topScore: 0,
+    })
+    expect(result.shouldShowCards).toBe(false)
+    expect(result.text).toContain('I mainly help with Nakhon Phanom travel')
+  })
+})

--- a/src/lib/chatResponsePolicy.test.ts
+++ b/src/lib/chatResponsePolicy.test.ts
@@ -51,7 +51,7 @@ describe('decideChatResponse', () => {
     })
     expect(result.confidence).toBe('medium')
     expect(result.shouldShowCards).toBe(true)
-    expect(result.text).toContain('สถานที่ขอพรเรื่องบุตรหรือสายบุญ')
+    expect(result.text).toContain('สถานที่ขอพรเรื่องบุตร')
   })
 
   it('returns grounded high-confidence wording for strong matches', () => {
@@ -71,6 +71,17 @@ describe('decideChatResponse', () => {
       guard: guard({ language: 'th', travelHint: undefined }),
       searchResultCount: 2,
       topScore: 22,
+    })
+    expect(result.confidence).toBe('low')
+    expect(result.shouldShowCards).toBe(false)
+    expect(result.text).toContain('ผมยังไม่แน่ใจ')
+  })
+
+  it('allows generic travel hints to fall back to clarification at low confidence', () => {
+    const result = decideChatResponse({
+      guard: guard({ language: 'th', travelHint: 'general' }),
+      searchResultCount: 2,
+      topScore: 24,
     })
     expect(result.confidence).toBe('low')
     expect(result.shouldShowCards).toBe(false)

--- a/src/lib/chatResponsePolicy.ts
+++ b/src/lib/chatResponsePolicy.ts
@@ -1,0 +1,137 @@
+import type { ChatGuardResult } from './chatGuard'
+
+export type SearchConfidence = 'high' | 'medium' | 'low'
+
+export type ChatResponseDecision = {
+  confidence: SearchConfidence
+  shouldShowCards: boolean
+  text: string
+}
+
+type ResponsePolicyInput = {
+  guard: ChatGuardResult
+  searchResultCount: number
+  topScore: number
+}
+
+function thaiOffTopic(): ChatResponseDecision {
+  return {
+    confidence: 'low',
+    shouldShowCards: false,
+    text: 'ผมช่วยเรื่องเที่ยวนครพนมเป็นหลักครับ ถ้าอยากให้แนะนำ ลองพิมพ์ เช่น “ขอที่เที่ยวสายบุญ”, “หาร้านอาหารเช้า”, หรือ “วางแผนเที่ยวครึ่งวัน”',
+  }
+}
+
+function englishOffTopic(): ChatResponseDecision {
+  return {
+    confidence: 'low',
+    shouldShowCards: false,
+    text: 'I mainly help with Nakhon Phanom travel. Try asking for temples, food, nature spots, photo spots, or a half-day plan.',
+  }
+}
+
+function thaiPause(): ChatResponseDecision {
+  return {
+    confidence: 'low',
+    shouldShowCards: false,
+    text: 'ได้ครับ พิมพ์ต่อได้เลย ถ้าอยากให้ช่วยเรื่องที่เที่ยว ร้านอาหาร หรือวางแผนทริปนครพนม',
+  }
+}
+
+function englishPause(): ChatResponseDecision {
+  return {
+    confidence: 'low',
+    shouldShowCards: false,
+    text: 'No problem. Continue when you are ready.',
+  }
+}
+
+function thaiUnclear(): ChatResponseDecision {
+  return {
+    confidence: 'low',
+    shouldShowCards: false,
+    text: 'ผมยังไม่แน่ใจว่าคุณอยากหาอะไรในนครพนมครับ อยากได้วัด ร้านอาหาร คาเฟ่ ธรรมชาติ หรือให้ผมวางแผนทริปให้?',
+  }
+}
+
+function englishUnclear(): ChatResponseDecision {
+  return {
+    confidence: 'low',
+    shouldShowCards: false,
+    text: 'I am not sure what kind of place you want. Do you mean temples, food, cafes, nature, or a trip plan?',
+  }
+}
+
+function computeConfidence(topScore: number, hasTravelHint: boolean): SearchConfidence {
+  if (topScore >= 75) return 'high'
+  if (topScore >= 55 || hasTravelHint) return 'medium'
+  return 'low'
+}
+
+export function decideChatResponse({
+  guard,
+  searchResultCount,
+  topScore,
+}: ResponsePolicyInput): ChatResponseDecision {
+  const thai = guard.language === 'th'
+
+  if (guard.intent === 'off_topic') {
+    return thai ? thaiOffTopic() : englishOffTopic()
+  }
+
+  if (guard.intent === 'pause') {
+    return thai ? thaiPause() : englishPause()
+  }
+
+  if (guard.intent === 'unclear') {
+    return thai ? thaiUnclear() : englishUnclear()
+  }
+
+  if (guard.intent === 'travel_plan') {
+    return {
+      confidence: 'high',
+      shouldShowCards: false,
+      text: thai
+        ? 'ได้ครับ ผมจะช่วยจัดทริปนครพนมให้ตามคำขอของคุณ'
+        : 'I can help plan a Nakhon Phanom trip for that request.',
+    }
+  }
+
+  const confidence = computeConfidence(topScore, Boolean(guard.travelHint))
+  if (confidence === 'low' || searchResultCount === 0) {
+    return thai ? thaiUnclear() : englishUnclear()
+  }
+
+  if (thai) {
+    if (guard.travelHint === 'blessing') {
+      return {
+        confidence,
+        shouldShowCards: true,
+        text:
+          confidence === 'high'
+            ? 'ผมเจอตัวเลือกที่ตรงกับคำขอของคุณ ลองเริ่มจากที่นี่ครับ'
+            : 'ถ้าคุณหมายถึงสถานที่ขอพรเรื่องบุตรหรือสายบุญในนครพนม ผมจะแนะนำตัวเลือกที่เกี่ยวกับวัดและการขอพรให้ครับ',
+      }
+    }
+
+    return {
+      confidence,
+      shouldShowCards: true,
+      text:
+        confidence === 'high'
+          ? 'ผมเจอตัวเลือกที่ตรงกับคำขอของคุณ ลองเริ่มจากที่นี่ครับ'
+          : 'ผมเดาว่าคุณอาจกำลังมองหาสถานที่แนวนี้ ลองดูตัวเลือกเหล่านี้ก่อนครับ',
+    }
+  }
+
+  return {
+    confidence,
+    shouldShowCards: true,
+    text:
+      confidence === 'high'
+        ? 'I found options that fit what you asked for. Start here.'
+        : guard.travelHint === 'blessing'
+        ? 'If you mean blessing or fertility-related places in Nakhon Phanom, these temple options are the closest fit.'
+        : 'I think these may be the kind of places you mean. Try these options first.',
+  }
+}

--- a/src/lib/chatResponsePolicy.ts
+++ b/src/lib/chatResponsePolicy.ts
@@ -74,6 +74,7 @@ export function decideChatResponse({
   topScore,
 }: ResponsePolicyInput): ChatResponseDecision {
   const thai = guard.language === 'th'
+  const hasStrongTravelHint = Boolean(guard.travelHint && guard.travelHint !== 'general')
 
   if (guard.intent === 'off_topic') {
     return thai ? thaiOffTopic() : englishOffTopic()
@@ -97,7 +98,7 @@ export function decideChatResponse({
     }
   }
 
-  const confidence = computeConfidence(topScore, Boolean(guard.travelHint))
+  const confidence = computeConfidence(topScore, hasStrongTravelHint)
   if (confidence === 'low' || searchResultCount === 0) {
     return thai ? thaiUnclear() : englishUnclear()
   }

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -202,12 +202,17 @@ export default function MapPage() {
     navigate(`/entry/${id}`)
   }
 
-  const prepareFreshResults = () => {
+  const clearVisibleResults = () => {
+    setActiveSearch(null)
     setActivePlan(null)
     setRouteRevealedSegments(0)
+    setSheetState('peek')
+  }
+
+  const prepareFreshResults = () => {
+    clearVisibleResults()
     setSelectedChipIds([])
     setActiveThemeId(null)
-    setActiveSearch(null)
   }
 
   const resolveSearchResults = async (query: string): Promise<ActiveSearch> => {
@@ -267,6 +272,7 @@ export default function MapPage() {
       const shouldPlan = options?.forcePlan || guard.intent === 'travel_plan'
 
       if (guard.intent === 'pause' || guard.intent === 'off_topic' || guard.intent === 'unclear') {
+        clearVisibleResults()
         const response = decideChatResponse({
           guard,
           searchResultCount: 0,
@@ -310,14 +316,17 @@ export default function MapPage() {
           searchResultCount: search.results.length,
           topScore: search.results[0]?.score ?? 0,
         })
+        if (!response.shouldShowCards) {
+          clearVisibleResults()
+        }
         if (options?.appendToChat) {
-            addChatMessage({
-              id: `assistant-search-${Date.now()}`,
-              role: 'assistant',
-              text: response.text,
-              language: guard.language,
-              results: response.shouldShowCards ? search.results.slice(0, 3) : undefined,
-            })
+          addChatMessage({
+            id: `assistant-search-${Date.now()}`,
+            role: 'assistant',
+            text: response.text,
+            language: guard.language,
+            results: response.shouldShowCards ? search.results.slice(0, 3) : undefined,
+          })
         }
       }
     } catch {

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -20,6 +20,8 @@ import {
   shouldUsePlanMode,
 } from '../lib/intentSearch'
 import { searchIntentHits } from '../lib/api'
+import { classifyChatIntent, type ChatLanguage } from '../lib/chatGuard'
+import { decideChatResponse } from '../lib/chatResponsePolicy'
 import { getPlan, type Plan } from '../lib/plan'
 import { useAppStore } from '../store/useAppStore'
 import type { Entry } from '../types'
@@ -41,6 +43,7 @@ type ChatMessage = {
   id: string
   role: 'assistant' | 'user'
   text: string
+  language?: ChatLanguage
   results?: RankedSearchResult[]
   plan?: Plan
 }
@@ -78,19 +81,6 @@ function buildPlanPrompt(selections: PlanMyDaySelections): string {
   }
 
   return `Plan ${durationText[selections.duration]} in Nakhon Phanom with a ${paceText[selections.pace]} pace focused on ${vibeText[selections.vibe]}.`
-}
-
-function buildSearchReply(query: string, results: RankedSearchResult[]): string {
-  if (results.length === 0) {
-    return `I could not find a strong match for "${query}", but you can still explore the map and nearby picks.`
-  }
-
-  const [first, second] = results
-  if (!second) {
-    return `I found one strong match for "${query}". ${first.entry.name_en} looks like the best place to start.`
-  }
-
-  return `I found ${results.length} matches for "${query}". Start with ${first.entry.name_en}, then keep ${second.entry.name_en} as a strong backup.`
 }
 
 function buildPlanReply(plan: Plan): string {
@@ -259,18 +249,14 @@ export default function MapPage() {
   ) => {
     const normalized = query.trim()
     if (!normalized) return
-
-    prepareFreshResults()
-
-    if (options?.switchToMap) {
-      setViewMode('map')
-    }
+    const guard = classifyChatIntent(normalized)
 
     if (options?.appendToChat) {
       addChatMessage({
         id: `user-${Date.now()}`,
         role: 'user',
         text: normalized,
+        language: guard.language,
       })
       setChatThinking(true)
     }
@@ -278,8 +264,33 @@ export default function MapPage() {
     setChatbotLoading(true)
 
     try {
-      if (options?.forcePlan || shouldUsePlanMode(normalized)) {
-        const plan = await getPlan(normalized, 'nkp')
+      const shouldPlan = options?.forcePlan || guard.intent === 'travel_plan'
+
+      if (guard.intent === 'pause' || guard.intent === 'off_topic' || guard.intent === 'unclear') {
+        const response = decideChatResponse({
+          guard,
+          searchResultCount: 0,
+          topScore: 0,
+        })
+        if (options?.appendToChat) {
+          addChatMessage({
+            id: `assistant-guard-${Date.now()}`,
+            role: 'assistant',
+            text: response.text,
+            language: guard.language,
+          })
+        }
+        return
+      }
+
+      if (options?.switchToMap) {
+        setViewMode('map')
+      }
+
+      prepareFreshResults()
+
+      if (shouldPlan || shouldUsePlanMode(guard.normalizedQuery)) {
+        const plan = await getPlan(guard.normalizedQuery, 'nkp')
         setActivePlan(plan)
         setSheetState('full')
 
@@ -288,18 +299,25 @@ export default function MapPage() {
             id: `assistant-plan-${Date.now()}`,
             role: 'assistant',
             text: buildPlanReply(plan),
+            language: guard.language,
             plan,
           })
         }
       } else {
-        const search = await resolveSearchResults(normalized)
+        const search = await resolveSearchResults(guard.normalizedQuery)
+        const response = decideChatResponse({
+          guard,
+          searchResultCount: search.results.length,
+          topScore: search.results[0]?.score ?? 0,
+        })
         if (options?.appendToChat) {
-          addChatMessage({
-            id: `assistant-search-${Date.now()}`,
-            role: 'assistant',
-            text: buildSearchReply(normalized, search.results),
-            results: search.results.slice(0, 3),
-          })
+            addChatMessage({
+              id: `assistant-search-${Date.now()}`,
+              role: 'assistant',
+              text: response.text,
+              language: guard.language,
+              results: response.shouldShowCards ? search.results.slice(0, 3) : undefined,
+            })
         }
       }
     } catch {
@@ -648,6 +666,7 @@ export default function MapPage() {
                         entry={result.entry}
                         score={result.score}
                         matchedReasons={result.matchedReasons}
+                        language={message.language}
                         onTap={(entry) => handleCardTap(entry.id)}
                       />
                     ))}

--- a/tests/e2e/mvp-smoke.spec.ts
+++ b/tests/e2e/mvp-smoke.spec.ts
@@ -41,9 +41,11 @@ test.describe('frontend MVP smoke', () => {
   test('blessing and travel queries still work without exposing internal labels', async ({ page }) => {
     await page.goto('/app', { waitUntil: 'domcontentloaded' })
 
+    const topMatches = page.getByText('Top matches', { exact: true })
+
     await sendChatMessage(page, 'ขอลูก')
     await expect(page.getByText(/ขอพรเรื่องบุตร|ตรงกับคำขอของคุณ/)).toBeVisible()
-    await expect(page.getByText('Top matches')).toBeVisible()
+    await expect(topMatches.last()).toBeVisible()
     await expect(page.getByText('general_discovery')).toHaveCount(0)
     await expect(page.getByText('food_trip')).toHaveCount(0)
     await expect(page.getByText('grade:medium')).toHaveCount(0)
@@ -51,7 +53,7 @@ test.describe('frontend MVP smoke', () => {
     await expect(page.getByText('grade:low')).toHaveCount(0)
 
     await sendChatMessage(page, 'ไหว้พระ ขอพร')
-    await expect(page.getByText('Top matches')).toBeVisible()
+    await expect(topMatches.last()).toBeVisible()
 
     await page.getByRole('tab', { name: 'Map' }).click()
     await expect(page.getByRole('search')).toBeVisible()

--- a/tests/e2e/mvp-smoke.spec.ts
+++ b/tests/e2e/mvp-smoke.spec.ts
@@ -1,4 +1,9 @@
-import { expect, test } from 'playwright/test'
+import { expect, test, type Page } from 'playwright/test'
+
+async function sendChatMessage(page: Page, message: string) {
+  await page.getByLabel('Follow up').fill(message)
+  await page.getByRole('button', { name: 'Send chat message' }).click()
+}
 
 test.describe('frontend MVP smoke', () => {
   test('home loads and app toggles between chat and map', async ({ page }) => {
@@ -9,40 +14,60 @@ test.describe('frontend MVP smoke', () => {
 
     await page.goto('/app', { waitUntil: 'domcontentloaded' })
     await expect(page.getByRole('heading', { name: 'Concierge' })).toBeVisible()
-    await expect(
-      page.getByText('Ask me about blessings, food, nature, photo spots, or trip planning'),
-    ).toBeVisible()
+    await expect(page.getByPlaceholder('Follow up...')).toBeVisible()
 
     await page.getByRole('tab', { name: 'Map' }).click()
     await expect(page.getByRole('search')).toBeVisible()
     await expect(page.getByLabel('Ask about Nakhon Phanom')).toBeVisible()
   })
 
-  test('chat search shows assistant results and map keeps them accessible', async ({ page }) => {
+  test('off-topic, pause, and ambiguous prompts do not force recommendations', async ({ page }) => {
     await page.goto('/app', { waitUntil: 'domcontentloaded' })
 
-    const followUpInput = page.getByLabel('Follow up')
-    await followUpInput.fill('ไหว้พระ ขอพร')
-    await page.getByRole('button', { name: 'Send chat message' }).click()
+    await sendChatMessage(page, 'ไก่กับไข่อะไรเกิดก่อน')
+    await expect(page.getByText('ผมช่วยเรื่องเที่ยวนครพนมเป็นหลักครับ')).toBeVisible()
+    await expect(page.getByText('Top matches')).toHaveCount(0)
+    await expect(page.getByText('Pho Sawan')).toHaveCount(0)
 
-    await expect(page.getByText('Top matches')).toBeVisible()
-    await expect(page.getByRole('button', { name: /Wat Phra That Phanom/i }).first()).toBeVisible()
+    await sendChatMessage(page, 'เดียวนะ')
+    await expect(page.getByText('พิมพ์ต่อได้เลย')).toBeVisible()
+    await expect(page.getByText('Top matches')).toHaveCount(0)
 
-    await page.getByRole('tab', { name: 'Map' }).click()
-    await expect(page.getByText('Search results')).toBeVisible()
-    await expect(page.getByRole('button', { name: /Wat Phra That Phanom/i }).first()).toBeVisible()
+    await sendChatMessage(page, 'เอา')
+    await expect(page.getByText('ผมยังไม่แน่ใจว่าคุณอยากหาอะไรในนครพนมครับ')).toBeVisible()
+    await expect(page.getByText('Top matches')).toHaveCount(0)
   })
 
-  test('plan my day sheet creates a plan and keeps map accessible', async ({ page }) => {
+  test('blessing and travel queries still work without exposing internal labels', async ({ page }) => {
     await page.goto('/app', { waitUntil: 'domcontentloaded' })
+
+    await sendChatMessage(page, 'ขอลูก')
+    await expect(page.getByText(/ขอพรเรื่องบุตร|ตรงกับคำขอของคุณ/)).toBeVisible()
+    await expect(page.getByText('Top matches')).toBeVisible()
+    await expect(page.getByText('general_discovery')).toHaveCount(0)
+    await expect(page.getByText('food_trip')).toHaveCount(0)
+    await expect(page.getByText('grade:medium')).toHaveCount(0)
+    await expect(page.getByText('grade:high')).toHaveCount(0)
+    await expect(page.getByText('grade:low')).toHaveCount(0)
+
+    await sendChatMessage(page, 'ไหว้พระ ขอพร')
+    await expect(page.getByText('Top matches')).toBeVisible()
+
+    await page.getByRole('tab', { name: 'Map' }).click()
+    await expect(page.getByRole('search')).toBeVisible()
+  })
+
+  test('plan queries and plan-my-day sheet still create itineraries', async ({ page }) => {
+    await page.goto('/app', { waitUntil: 'domcontentloaded' })
+
+    await sendChatMessage(page, 'วางแผนเที่ยวครึ่งวัน')
+    await expect(page.getByText('Your plan')).toBeVisible()
 
     await page.getByRole('button', { name: 'Plan my day' }).click()
     await expect(page.getByRole('heading', { name: 'Plan my day' })).toBeVisible()
     await page.getByRole('button', { name: 'Food' }).click()
     await page.getByRole('button', { name: 'Create plan' }).click()
-
     await expect(page.getByText('Your plan')).toBeVisible()
-    await expect(page.getByText('Pho Sawan')).toBeVisible()
 
     await page.getByRole('tab', { name: 'Map' }).click()
     await expect(page.getByRole('search')).toBeVisible()


### PR DESCRIPTION
## Summary

Adds a conservative anti-hallucination layer to the concierge chat so unrelated, pause-like, or ambiguous messages no longer get forced into travel recommendations.

## What changed

- Added chat guard helpers to classify user input as:
  - travel search
  - travel plan
  - pause
  - off-topic
  - unclear
- Added response policy helpers for:
  - high / medium / low confidence
  - Thai/English safe assistant copy
  - clarification instead of low-confidence recommendations
- Added chat label cleanup so chat cards no longer expose internal labels like:
  - `general_discovery`
  - `food_trip`
  - `grade:medium`
- Wired the guard into the chat flow in `MapPage`
- Updated `ChatResultCard` to show user-facing labels only
- Expanded unit and e2e coverage for anti-hallucination behavior

## Behavior

- `ไก่กับไข่อะไรเกิดก่อน` now gets travel-scope guidance, no search, no cards
- `เดียวนะ` now gets a pause/help response, no search, no cards
- `เอา` now asks for clarification, no search, no cards
- `ขอลูก` still searches, but uses blessing-oriented wording
- `ไหว้พระ ขอพร` still searches and shows grounded cards
- `วางแผนเที่ยวครึ่งวัน` still triggers the existing plan flow

## Verification

- `npm.cmd test`
- `npm.cmd run build`
- `npm.cmd run test:e2e -- --reporter=list`
- `git diff --check`

## Notes

- Frontend-only change
- No backend changes
- No new dependencies
- No secrets or env changes
- Existing search and plan engines remain the source of truth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Chat interface now intelligently classifies user intent and provides tailored responses based on query type
  * Improved label display in search results with language-aware simplification
  * Enhanced response handling with confidence-based result visibility
  * Better support for multi-language chat interactions

* **Tests**
  * Added comprehensive test coverage for chat classification, response logic, and label handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->